### PR TITLE
feat(bls): bls-btrfs-snapshots binary — BLS Type #1 entry writer for btrfs snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ temp/
 
 /refind-btrfs-snapshots
 /kernel-spy
+/bls-btrfs-snapshots

--- a/cmd/bls-btrfs-snapshots/generate.go
+++ b/cmd/bls-btrfs-snapshots/generate.go
@@ -5,16 +5,17 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bls"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bootloader"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/cliconfig"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/config"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/discovery"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/fstab"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
-	"github.com/jmylchreest/refind-btrfs-snapshots/internal/refind"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/runner"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -26,52 +27,19 @@ var generateCmd = &cobra.Command{
 	RunE:  runGenerate,
 }
 
+var blsFlagToKey = map[string]string{
+	"dry-run": "dry_run",
+	"yes":     "yes",
+}
+
 func init() {
 	rootCmd.AddCommand(generateCmd)
 	generateCmd.Flags().Bool("dry-run", false, "Show what would be written without making changes")
 	generateCmd.Flags().BoolP("yes", "y", false, "Automatically approve all changes without prompting")
 }
 
-// configCandidates resolves the config path: --config flag wins, otherwise
-// prefer the binary-specific file and fall back to refind-btrfs-snapshots.yaml.
-func configCandidates(flagPath string) []string {
-	if flagPath != "" {
-		return []string{flagPath}
-	}
-	return []string{
-		"/etc/bls-btrfs-snapshots.yaml",
-		"/etc/refind-btrfs-snapshots.yaml",
-	}
-}
-
 func loadConfig(cmd *cobra.Command) (*config.Config, error) {
-	flagPath, _ := cmd.Flags().GetString("config")
-	for _, p := range configCandidates(flagPath) {
-		if _, err := os.Stat(p); err == nil {
-			cfg, err := config.Load(p, nil)
-			if err != nil {
-				return nil, err
-			}
-			log.Debug().Str("config_file", p).Msg("Loaded config")
-			applyFlagOverrides(cfg, cmd)
-			return cfg, nil
-		}
-	}
-	cfg, err := config.Load("", nil)
-	if err != nil {
-		return nil, err
-	}
-	applyFlagOverrides(cfg, cmd)
-	return cfg, nil
-}
-
-func applyFlagOverrides(cfg *config.Config, cmd *cobra.Command) {
-	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
-		cfg.DryRun = config.Truthy(true)
-	}
-	if yes, _ := cmd.Flags().GetBool("yes"); yes {
-		cfg.AutoApprove = config.Truthy(true)
-	}
+	return cliconfig.Load(cmd, "/etc/bls-btrfs-snapshots.yaml", blsFlagToKey)
 }
 
 func runGenerate(cmd *cobra.Command, args []string) error {
@@ -81,7 +49,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cfg.BLS.WriteEntries.IsTrue() {
-		log.Warn().Msg("bls.write_entries is false in config — nothing to do. Enable it in /etc/bls-btrfs-snapshots.yaml (or /etc/refind-btrfs-snapshots.yaml).")
+		log.Warn().Msg("bls.write_entries is false in config — nothing to do. Enable it in /etc/bls-btrfs-snapshots.yaml.")
 		return nil
 	}
 
@@ -120,12 +88,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	planner := kernel.NewPlanner(fstab.NewManager(), checker, bootSets, rootFS, ukiStrategy)
 	plans := planner.Plan(snapshots)
 
-	sourceEntries, err := extractSourceEntries(espPath, cfg.Refind.ConfigPath, rootFS)
-	if err != nil {
-		log.Warn().Err(err).Msg("Could not parse rEFInd source entries — BLS output may be empty")
-	}
+	entriesDir := filepath.Join(espPath, strings.TrimPrefix(cfg.BLS.EntriesDir, "/"))
+	sourceEntries := extractSourceEntries(entriesDir, cfg.BLS.EntryPrefix, bootSets)
 	if len(sourceEntries) == 0 {
-		log.Warn().Msg("No source boot entries found. The bls binary derives cmdlines from the system's primary bootloader config (currently expected: refind.conf).")
+		log.Warn().Msg("No source boot entries available. The bls binary derives cmdlines from existing BLS entries on the ESP, then /etc/kernel/cmdline, then /proc/cmdline. None produced usable templates.")
 	}
 
 	r := runner.New(cfg.DryRun.IsTrue())
@@ -224,38 +190,82 @@ func collectSnapshots(mgr *btrfs.Manager, selectionCount int) ([]*btrfs.Snapshot
 	return all, nil
 }
 
-// extractSourceEntries reads the system's rEFInd configuration to get the
-// canonical kernel + cmdline pairs. This is a v1 simplification — when
-// discovery is upgraded to populate BootSet.Cmdline directly, this lookup
-// will move into the discovery layer.
-func extractSourceEntries(espPath, configPath string, rootFS *btrfs.Filesystem) ([]bootloader.SourceEntry, error) {
-	parser := refind.NewParser(espPath)
-
-	if configPath == "" || configPath == "/EFI/refind/refind.conf" {
-		if found, err := parser.FindRefindConfigPath(); err == nil {
-			configPath = found
-		}
-	}
-	if !filepath.IsAbs(configPath) {
-		configPath = filepath.Join(espPath, configPath)
-	}
-
-	cfg, err := parser.ParseConfig(configPath)
-	if err != nil {
-		return nil, err
-	}
-
+// extractSourceEntries returns the templates the BLS generator clones per
+// snapshot. Primary source is existing non-managed BLS entries on the ESP
+// (what systemd-boot already reads); when that's empty, we synthesise one
+// per non-UKI BootSet using a cmdline read from /etc/kernel/cmdline or
+// /proc/cmdline.
+func extractSourceEntries(entriesDir, managedPrefix string, bootSets []*kernel.BootSet) []bootloader.SourceEntry {
+	scanned := bls.ScanEntriesDir(entriesDir)
 	var sources []bootloader.SourceEntry
-	for _, entry := range cfg.Entries {
-		if !refind.IsBootable(entry, rootFS) {
+	for _, e := range scanned {
+		if managedPrefix != "" && strings.HasPrefix(e.ID, managedPrefix) {
 			continue
 		}
+		if e.Linux == "" {
+			continue // not a Linux boot entry (could be Windows, EFI shell, etc.)
+		}
 		sources = append(sources, bootloader.SourceEntry{
-			Title:   entry.Title,
-			Loader:  entry.Loader,
-			Initrd:  entry.Initrd,
-			Options: entry.Options,
+			Title:   e.Title,
+			Loader:  e.Linux,
+			Initrd:  append([]string(nil), e.Initrd...),
+			Options: e.OptionsString(),
 		})
 	}
-	return sources, nil
+	if len(sources) > 0 {
+		log.Debug().Int("count", len(sources)).Msg("Using existing BLS entries as source templates")
+		return sources
+	}
+
+	cmdline, src, err := readFallbackCmdline()
+	if err != nil {
+		log.Warn().Err(err).Msg("No existing BLS entries and no cmdline fallback available")
+		return nil
+	}
+	log.Info().Str("source", src).Msg("No existing BLS entries on ESP — synthesising sources from BootSets")
+
+	for _, bs := range bootSets {
+		if bs.Layout == kernel.LayoutUKI || bs.Kernel == nil {
+			continue
+		}
+		se := bootloader.SourceEntry{
+			Title:   bs.DisplayName(),
+			Loader:  bs.Kernel.Path,
+			Options: cmdline,
+		}
+		if bs.Initramfs != nil {
+			se.Initrd = append(se.Initrd, bs.Initramfs.Path)
+		}
+		for _, mc := range bs.Microcode {
+			se.Initrd = append(se.Initrd, mc.Path)
+		}
+		sources = append(sources, se)
+	}
+	return sources
+}
+
+// readFallbackCmdline returns the kernel command line from the first
+// readable source. /etc/kernel/cmdline is the kernel-install / mkinitcpio
+// canonical location; /proc/cmdline is the running kernel as a last resort,
+// stripped of bootloader-injected initrd= and BOOT_IMAGE= tokens.
+func readFallbackCmdline() (string, string, error) {
+	if b, err := os.ReadFile("/etc/kernel/cmdline"); err == nil {
+		return strings.TrimSpace(string(b)), "/etc/kernel/cmdline", nil
+	}
+	if b, err := os.ReadFile("/proc/cmdline"); err == nil {
+		return stripProcCmdline(strings.TrimSpace(string(b))), "/proc/cmdline", nil
+	}
+	return "", "", fmt.Errorf("no readable cmdline at /etc/kernel/cmdline or /proc/cmdline")
+}
+
+func stripProcCmdline(s string) string {
+	keep := make([]string, 0, len(strings.Fields(s)))
+	for _, tok := range strings.Fields(s) {
+		lower := strings.ToLower(tok)
+		if strings.HasPrefix(lower, "initrd=") || strings.HasPrefix(lower, "boot_image=") {
+			continue
+		}
+		keep = append(keep, tok)
+	}
+	return strings.Join(keep, " ")
 }

--- a/cmd/bls-btrfs-snapshots/generate.go
+++ b/cmd/bls-btrfs-snapshots/generate.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bls"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bootloader"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/config"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/discovery"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/fstab"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/refind"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/runner"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Write BLS Type #1 entries for btrfs snapshots",
+	RunE:  runGenerate,
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+	generateCmd.Flags().Bool("dry-run", false, "Show what would be written without making changes")
+	generateCmd.Flags().BoolP("yes", "y", false, "Automatically approve all changes without prompting")
+}
+
+// configCandidates resolves the config path: --config flag wins, otherwise
+// prefer the binary-specific file and fall back to refind-btrfs-snapshots.yaml.
+func configCandidates(flagPath string) []string {
+	if flagPath != "" {
+		return []string{flagPath}
+	}
+	return []string{
+		"/etc/bls-btrfs-snapshots.yaml",
+		"/etc/refind-btrfs-snapshots.yaml",
+	}
+}
+
+func loadConfig(cmd *cobra.Command) (*config.Config, error) {
+	flagPath, _ := cmd.Flags().GetString("config")
+	for _, p := range configCandidates(flagPath) {
+		if _, err := os.Stat(p); err == nil {
+			cfg, err := config.Load(p, nil)
+			if err != nil {
+				return nil, err
+			}
+			log.Debug().Str("config_file", p).Msg("Loaded config")
+			applyFlagOverrides(cfg, cmd)
+			return cfg, nil
+		}
+	}
+	cfg, err := config.Load("", nil)
+	if err != nil {
+		return nil, err
+	}
+	applyFlagOverrides(cfg, cmd)
+	return cfg, nil
+}
+
+func applyFlagOverrides(cfg *config.Config, cmd *cobra.Command) {
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		cfg.DryRun = config.Truthy(true)
+	}
+	if yes, _ := cmd.Flags().GetBool("yes"); yes {
+		cfg.AutoApprove = config.Truthy(true)
+	}
+}
+
+func runGenerate(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	if !cfg.BLS.WriteEntries.IsTrue() {
+		log.Warn().Msg("bls.write_entries is false in config — nothing to do. Enable it in /etc/bls-btrfs-snapshots.yaml (or /etc/refind-btrfs-snapshots.yaml).")
+		return nil
+	}
+
+	espPath, err := discovery.ResolveESP(discovery.ESPOptions{
+		UUID:       cfg.ESP.UUID,
+		AutoDetect: cfg.ESP.AutoDetect.IsTrue(),
+		MountPoint: cfg.ESP.MountPoint,
+	})
+	if err != nil {
+		return fmt.Errorf("resolve ESP: %w", err)
+	}
+
+	bootSets, _ := discovery.DetectBootSets(
+		discovery.ESPOptions{UUID: cfg.ESP.UUID, AutoDetect: cfg.ESP.AutoDetect.IsTrue(), MountPoint: cfg.ESP.MountPoint},
+		patternsFromConfig(cfg.Kernel.BootImagePatterns),
+	)
+
+	btrfsMgr := btrfs.NewManager(cfg.Snapshot.SearchDirectories, cfg.Snapshot.MaxDepth, cfg.Advanced.Naming.RwsnapFormat, cfg.Display.LocalTime.IsTrue())
+	rootFS, err := btrfsMgr.GetRootFilesystem()
+	if err != nil {
+		return fmt.Errorf("locate root btrfs filesystem: %w", err)
+	}
+
+	snapshots, err := collectSnapshots(btrfsMgr, cfg.Snapshot.SelectionCount)
+	if err != nil {
+		return fmt.Errorf("discover snapshots: %w", err)
+	}
+	if len(snapshots) == 0 {
+		log.Info().Msg("No snapshots found — nothing to do")
+		return nil
+	}
+
+	staleAction := kernel.ParseStaleAction(cfg.Kernel.StaleSnapshotAction)
+	checker := kernel.NewChecker(staleAction)
+	ukiStrategy := kernel.ParseUKIStrategy(cfg.UKI.SnapshotStrategy)
+	planner := kernel.NewPlanner(fstab.NewManager(), checker, bootSets, rootFS, ukiStrategy)
+	plans := planner.Plan(snapshots)
+
+	sourceEntries, err := extractSourceEntries(espPath, cfg.Refind.ConfigPath, rootFS)
+	if err != nil {
+		log.Warn().Err(err).Msg("Could not parse rEFInd source entries — BLS output may be empty")
+	}
+	if len(sourceEntries) == 0 {
+		log.Warn().Msg("No source boot entries found. The bls binary derives cmdlines from the system's primary bootloader config (currently expected: refind.conf).")
+	}
+
+	r := runner.New(cfg.DryRun.IsTrue())
+	gen := bls.NewGenerator()
+	out, err := gen.Generate(bootloader.Input{
+		Cfg:                cfg,
+		ESPPath:            espPath,
+		RootFS:             rootFS,
+		ProcessedSnapshots: snapshots,
+		BootPlans:          plans,
+		SourceEntries:      sourceEntries,
+	})
+	if err != nil {
+		return fmt.Errorf("bls generator: %w", err)
+	}
+
+	patch := diff.NewPatchDiff()
+	for _, d := range out.Diffs {
+		patch.AddFile(d)
+	}
+
+	if len(patch.Files) == 0 {
+		log.Info().Msg("No changes needed - BLS entries are up to date")
+		return nil
+	}
+
+	if r.IsDryRun() {
+		diff.ShowPatchWithPager(patch, !cfg.AutoApprove.IsTrue())
+		log.Info().Msg("[DRY RUN] Would apply all changes shown above")
+		return nil
+	}
+
+	if !cfg.AutoApprove.IsTrue() {
+		if !diff.ConfirmPatchChanges(patch, false) {
+			log.Info().Msg("User declined changes - operation cancelled")
+			return nil
+		}
+	} else {
+		diff.ShowPatchWithPager(patch, false)
+	}
+
+	if err := diff.Apply(patch, r); err != nil {
+		return fmt.Errorf("apply BLS entries: %w", err)
+	}
+	log.Info().Int("entries", len(out.Diffs)).Msg("BLS entries written")
+	return nil
+}
+
+// patternsFromConfig drops invalid roles and returns the typed list the
+// kernel scanner accepts.
+func patternsFromConfig(cfgPatterns []config.PatternConfig) []kernel.PatternConfig {
+	var out []kernel.PatternConfig
+	for _, p := range cfgPatterns {
+		role, err := kernel.ParseImageRole(p.Role)
+		if err != nil {
+			log.Warn().Err(err).Str("glob", p.Glob).Msg("Invalid role in boot_image_patterns, skipping")
+			continue
+		}
+		out = append(out, kernel.PatternConfig{
+			Glob:        p.Glob,
+			Role:        role,
+			StripPrefix: p.StripPrefix,
+			StripSuffix: p.StripSuffix,
+			KernelName:  p.KernelName,
+		})
+	}
+	return out
+}
+
+// collectSnapshots walks all detected btrfs filesystems and returns the
+// deduplicated, newest-first set of snapshots, trimmed to selectionCount.
+func collectSnapshots(mgr *btrfs.Manager, selectionCount int) ([]*btrfs.Snapshot, error) {
+	filesystems, err := mgr.DetectBtrfsFilesystems()
+	if err != nil {
+		return nil, err
+	}
+	var all []*btrfs.Snapshot
+	seen := make(map[string]bool)
+	for _, fs := range filesystems {
+		snaps, err := mgr.FindSnapshots(fs)
+		if err != nil {
+			log.Warn().Err(err).Str("fs", fs.GetBestIdentifier()).Msg("Snapshot discovery failed")
+			continue
+		}
+		for _, s := range snaps {
+			if !seen[s.Path] {
+				seen[s.Path] = true
+				all = append(all, s)
+			}
+		}
+	}
+	slices.SortFunc(all, func(a, b *btrfs.Snapshot) int { return b.SnapshotTime.Compare(a.SnapshotTime) })
+	if selectionCount > 0 && len(all) > selectionCount {
+		all = all[:selectionCount]
+	}
+	return all, nil
+}
+
+// extractSourceEntries reads the system's rEFInd configuration to get the
+// canonical kernel + cmdline pairs. This is a v1 simplification — when
+// discovery is upgraded to populate BootSet.Cmdline directly, this lookup
+// will move into the discovery layer.
+func extractSourceEntries(espPath, configPath string, rootFS *btrfs.Filesystem) ([]bootloader.SourceEntry, error) {
+	parser := refind.NewParser(espPath)
+
+	if configPath == "" || configPath == "/EFI/refind/refind.conf" {
+		if found, err := parser.FindRefindConfigPath(); err == nil {
+			configPath = found
+		}
+	}
+	if !filepath.IsAbs(configPath) {
+		configPath = filepath.Join(espPath, configPath)
+	}
+
+	cfg, err := parser.ParseConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var sources []bootloader.SourceEntry
+	for _, entry := range cfg.Entries {
+		if !refind.IsBootable(entry, rootFS) {
+			continue
+		}
+		sources = append(sources, bootloader.SourceEntry{
+			Title:   entry.Title,
+			Loader:  entry.Loader,
+			Initrd:  entry.Initrd,
+			Options: entry.Options,
+		})
+	}
+	return sources, nil
+}

--- a/cmd/bls-btrfs-snapshots/generate.go
+++ b/cmd/bls-btrfs-snapshots/generate.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 	generateCmd.Flags().Bool("dry-run", false, "Show what would be written without making changes")
 	generateCmd.Flags().BoolP("yes", "y", false, "Automatically approve all changes without prompting")
+	generateCmd.Flags().Bool("force", false, "Force generation even if booted from a snapshot")
 }
 
 func loadConfig(cmd *cobra.Command) (*config.Config, error) {
@@ -71,6 +72,12 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	rootFS, err := btrfsMgr.GetRootFilesystem()
 	if err != nil {
 		return fmt.Errorf("locate root btrfs filesystem: %w", err)
+	}
+
+	force, _ := cmd.Flags().GetBool("force")
+	if !force && cfg.Behavior.ExitOnSnapshotBoot.IsTrue() && btrfsMgr.IsSnapshotBootFromRootFS(rootFS) {
+		log.Warn().Str("subvolume", rootFS.Subvolume.Path).Msg("Currently booted from a snapshot. Use --force to override or set behavior.exit_on_snapshot_boot=false in config.")
+		return fmt.Errorf("refusing to generate BLS entries while booted from snapshot")
 	}
 
 	snapshots, err := collectSnapshots(btrfsMgr, cfg.Snapshot.SelectionCount)

--- a/cmd/bls-btrfs-snapshots/generate.go
+++ b/cmd/bls-btrfs-snapshots/generate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/fstab"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/runner"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/snapshotfs"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -116,6 +117,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	patch := diff.NewPatchDiff()
+	for _, u := range snapshotfs.UpdateFstabs(snapshots, rootFS, fstab.NewManager()) {
+		patch.AddFile(u.Diff)
+	}
 	for _, d := range out.Diffs {
 		patch.AddFile(d)
 	}

--- a/cmd/bls-btrfs-snapshots/generate_test.go
+++ b/cmd/bls-btrfs-snapshots/generate_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeEntry(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+}
+
+func TestExtractSourceEntries_ExistingBLSEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "arch.conf", `title    Arch Linux
+linux    /vmlinuz-linux
+initrd   /intel-ucode.img
+initrd   /initramfs-linux.img
+options  root=UUID=abc rw quiet
+`)
+	writeEntry(t, dir, "bls-btrfs-snapshots-existing.conf", `title    Managed
+linux    /vmlinuz-linux
+options  root=UUID=abc
+`)
+	writeEntry(t, dir, "windows.conf", `title    Windows
+efi      /EFI/Microsoft/Boot/bootmgfw.efi
+`)
+
+	srcs := extractSourceEntries(dir, "bls-btrfs-snapshots-", nil)
+
+	require.Len(t, srcs, 1, "managed-prefix entries filtered; entries without linux= skipped")
+	assert.Equal(t, "Arch Linux", srcs[0].Title)
+	assert.Equal(t, "/vmlinuz-linux", srcs[0].Loader)
+	assert.Equal(t, []string{"/intel-ucode.img", "/initramfs-linux.img"}, srcs[0].Initrd)
+	assert.Equal(t, "root=UUID=abc rw quiet", srcs[0].Options)
+}
+
+func TestExtractSourceEntries_FallbackFromBootSets(t *testing.T) {
+	dir := t.TempDir() // empty, forces fallback
+
+	t.Setenv("HOME", t.TempDir()) // belt-and-braces; readFallbackCmdline uses absolute paths
+	bootSets := []*kernel.BootSet{
+		{
+			KernelName: "linux",
+			Layout:     kernel.LayoutSplit,
+			Kernel:     &kernel.BootImage{Path: "/vmlinuz-linux"},
+			Initramfs:  &kernel.BootImage{Path: "/initramfs-linux.img"},
+			Microcode:  []*kernel.BootImage{{Path: "/intel-ucode.img"}},
+		},
+		{
+			KernelName: "linux-zen",
+			Layout:     kernel.LayoutUKI, // must be skipped by fallback
+			UKI:        &kernel.BootImage{Path: "/EFI/Linux/linux-zen.efi"},
+		},
+	}
+
+	// The fallback reads /etc/kernel/cmdline then /proc/cmdline; we don't
+	// control either from a test. Skip if neither is readable in this env.
+	if _, errKern := os.Stat("/etc/kernel/cmdline"); errKern != nil {
+		if _, errProc := os.Stat("/proc/cmdline"); errProc != nil {
+			t.Skip("no system cmdline source available in test environment")
+		}
+	}
+
+	srcs := extractSourceEntries(dir, "bls-btrfs-snapshots-", bootSets)
+
+	require.Len(t, srcs, 1, "UKI BootSet must be excluded from fallback synthesis")
+	assert.Equal(t, "/vmlinuz-linux", srcs[0].Loader)
+	assert.Equal(t, []string{"/initramfs-linux.img", "/intel-ucode.img"}, srcs[0].Initrd)
+	assert.NotEmpty(t, srcs[0].Options, "fallback cmdline must be non-empty")
+}
+
+func TestExtractSourceEntries_NoEntriesNoBootSets(t *testing.T) {
+	dir := t.TempDir()
+	srcs := extractSourceEntries(dir, "bls-btrfs-snapshots-", nil)
+	assert.Empty(t, srcs, "no BLS entries and no BootSets → no sources")
+}
+
+func TestStripProcCmdline(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "strips_initrd_and_boot_image",
+			in:   "BOOT_IMAGE=/vmlinuz-linux root=UUID=abc rw initrd=/initramfs-linux.img quiet",
+			want: "root=UUID=abc rw quiet",
+		},
+		{
+			name: "case_insensitive_keys",
+			in:   "BOOT_IMAGE=/x initrd=/y Initrd=/z BOOT_image=/w root=UUID=abc",
+			want: "root=UUID=abc",
+		},
+		{
+			name: "preserves_other_tokens",
+			in:   "root=UUID=abc rw quiet splash",
+			want: "root=UUID=abc rw quiet splash",
+		},
+		{
+			name: "empty_input",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripProcCmdline(tt.in))
+		})
+	}
+}

--- a/cmd/bls-btrfs-snapshots/main.go
+++ b/cmd/bls-btrfs-snapshots/main.go
@@ -16,12 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	Version   = "dev"
-	Commit    = "unknown"
-	BuildTime = "unknown"
-)
-
 var rootCmd = &cobra.Command{
 	Use:   "bls-btrfs-snapshots",
 	Short: "Write BLS Type #1 entries for btrfs snapshots",
@@ -35,7 +29,7 @@ for btrfs-mode coverage via rEFInd's btrfs driver.`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to config file (default: /etc/bls-btrfs-snapshots.yaml, falls back to /etc/refind-btrfs-snapshots.yaml)")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to config file (default: /etc/bls-btrfs-snapshots.yaml)")
 	rootCmd.PersistentFlags().String("log-level", "", "Log verbosity: trace, debug, info, warn, error")
 }
 

--- a/cmd/bls-btrfs-snapshots/main.go
+++ b/cmd/bls-btrfs-snapshots/main.go
@@ -1,0 +1,60 @@
+// bls-btrfs-snapshots writes Boot Loader Specification Type #1 entries for
+// btrfs snapshots, consumed by systemd-boot and BLS-aware GRUB builds.
+// rEFInd users should use refind-btrfs-snapshots instead — it generates
+// rEFInd-native config and handles btrfs-mode boot via rEFInd's btrfs driver,
+// which systemd-boot lacks.
+//
+// Spec: https://uapi-group.org/specifications/specs/boot_loader_specification/
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildTime = "unknown"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bls-btrfs-snapshots",
+	Short: "Write BLS Type #1 entries for btrfs snapshots",
+	Long: `Discover btrfs snapshots and emit BLS Type #1 entries under
+<esp>/loader/entries/, consumed by systemd-boot or BLS-aware GRUB.
+
+Only ESP-mode snapshots are emitted: systemd-boot cannot traverse btrfs
+subvolumes to reach kernels inside a snapshot. Use refind-btrfs-snapshots
+for btrfs-mode coverage via rEFInd's btrfs driver.`,
+	PersistentPreRunE: setupLogging,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to config file (default: /etc/bls-btrfs-snapshots.yaml, falls back to /etc/refind-btrfs-snapshots.yaml)")
+	rootCmd.PersistentFlags().String("log-level", "", "Log verbosity: trace, debug, info, warn, error")
+}
+
+func setupLogging(cmd *cobra.Command, args []string) error {
+	level, _ := cmd.Flags().GetString("log-level")
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	if level != "" {
+		parsed, err := zerolog.ParseLevel(level)
+		if err != nil {
+			return fmt.Errorf("invalid --log-level %q: %w", level, err)
+		}
+		zerolog.SetGlobalLevel(parsed)
+	}
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
+	return nil
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/bls-btrfs-snapshots/main.go
+++ b/cmd/bls-btrfs-snapshots/main.go
@@ -34,17 +34,33 @@ func init() {
 }
 
 func setupLogging(cmd *cobra.Command, args []string) error {
-	level, _ := cmd.Flags().GetString("log-level")
+	level := levelFromFlagThenConfig(cmd)
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if level != "" {
 		parsed, err := zerolog.ParseLevel(level)
 		if err != nil {
-			return fmt.Errorf("invalid --log-level %q: %w", level, err)
+			return fmt.Errorf("invalid log level %q: %w", level, err)
 		}
 		zerolog.SetGlobalLevel(parsed)
 	}
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
 	return nil
+}
+
+// levelFromFlagThenConfig returns --log-level if explicitly set, otherwise
+// reads log_level from the YAML config (so users can pin a default without
+// always passing the flag). Errors during config load are non-fatal here —
+// runGenerate re-loads and surfaces the real error.
+func levelFromFlagThenConfig(cmd *cobra.Command) string {
+	if cmd.Flags().Changed("log-level") {
+		v, _ := cmd.Flags().GetString("log-level")
+		return v
+	}
+	cfg, err := loadConfig(cmd)
+	if err != nil {
+		return ""
+	}
+	return cfg.LogLevel
 }
 
 func main() {

--- a/cmd/bls-btrfs-snapshots/main_test.go
+++ b/cmd/bls-btrfs-snapshots/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.PersistentFlags().StringP("config", "c", "", "config file")
+	cmd.PersistentFlags().String("log-level", "", "log level")
+	return cmd
+}
+
+func TestLevelFromFlagThenConfig_FlagWins(t *testing.T) {
+	cmd := newTestCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{"--log-level=trace"}))
+
+	assert.Equal(t, "trace", levelFromFlagThenConfig(cmd),
+		"explicit --log-level must take precedence over config")
+}
+
+func TestLevelFromFlagThenConfig_ConfigFallback(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bls.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("log_level: warn\n"), 0o644))
+
+	cmd := newTestCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{"--config=" + cfgPath}))
+
+	assert.Equal(t, "warn", levelFromFlagThenConfig(cmd),
+		"with no --log-level, cfg.LogLevel from YAML must be returned")
+}
+
+func TestLevelFromFlagThenConfig_NoFlagNoConfig(t *testing.T) {
+	cmd := newTestCmd(t)
+	require.NoError(t, cmd.ParseFlags(nil))
+
+	// Default config has LogLevel="info" — not empty. The contract here is
+	// "no panic, returns whatever defaults produce" so we just assert the
+	// function returns without error and yields a non-panicking value.
+	assert.NotPanics(t, func() {
+		_ = levelFromFlagThenConfig(cmd)
+	})
+}

--- a/cmd/bls-btrfs-snapshots/version.go
+++ b/cmd/bls-btrfs-snapshots/version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("bls-btrfs-snapshots %s\n", Version)
+		fmt.Printf("Commit: %s\n", Commit)
+		fmt.Printf("Built: %s\n", BuildTime)
+		fmt.Printf("Go version: %s\n", runtime.Version())
+	},
+}

--- a/cmd/bls-btrfs-snapshots/version.go
+++ b/cmd/bls-btrfs-snapshots/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -15,9 +16,9 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("bls-btrfs-snapshots %s\n", Version)
-		fmt.Printf("Commit: %s\n", Commit)
-		fmt.Printf("Built: %s\n", BuildTime)
+		fmt.Printf("bls-btrfs-snapshots %s\n", version.String())
+		fmt.Printf("Commit: %s\n", version.Commit)
+		fmt.Printf("Built: %s\n", version.BuildTime)
 		fmt.Printf("Go version: %s\n", runtime.Version())
 	},
 }

--- a/cmd/bls-btrfs-snapshots/version_test.go
+++ b/cmd/bls-btrfs-snapshots/version_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	fn()
+	require.NoError(t, w.Close())
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return strings.TrimSpace(string(data))
+}
+
+func TestVersionCmd_OutputFormat(t *testing.T) {
+	origV, origC, origB := version.Version, version.Commit, version.BuildTime
+	t.Cleanup(func() {
+		version.Version, version.Commit, version.BuildTime = origV, origC, origB
+	})
+	version.Version = "1.2.3"
+	version.Commit = "abcdef1"
+	version.BuildTime = "2026-01-01T00:00:00Z"
+
+	output := captureStdout(t, func() { versionCmd.Run(nil, nil) })
+
+	assert.Contains(t, output, "bls-btrfs-snapshots 1.2.3")
+	assert.Contains(t, output, "Commit: abcdef1")
+	assert.Contains(t, output, "Built: 2026-01-01T00:00:00Z")
+	assert.Contains(t, output, "Go version: go")
+}

--- a/configs/bls-btrfs-snapshots.yaml
+++ b/configs/bls-btrfs-snapshots.yaml
@@ -1,0 +1,32 @@
+# bls-btrfs-snapshots configuration
+#
+# Writes Boot Loader Specification Type #1 entries to <esp>/loader/entries/,
+# consumed by systemd-boot and BLS-aware GRUB. rEFInd users should run
+# refind-btrfs-snapshots instead.
+#
+# Discovery settings (snapshot search dirs, ESP detection, kernel patterns)
+# default to the same values as refind-btrfs-snapshots — they live in the
+# code and only need to appear here if you want to override them. The full
+# reference is configs/refind-btrfs-snapshots.yaml.
+#
+# Spec: https://uapi-group.org/specifications/specs/boot_loader_specification/
+
+# BLS output
+bls:
+  # Toggle the writer. Off by default so installing the binary alone is
+  # never enough to produce changes — opt in explicitly.
+  write_entries: true
+
+  # Where entries go. Absolute path relative to the ESP root.
+  entries_dir: "/loader/entries"
+
+  # Prefix that identifies entries managed by this tool. Orphans matching
+  # this prefix get cleaned up automatically when their snapshot disappears.
+  entry_prefix: "bls-btrfs-snapshots-"
+
+# Behaviour
+behavior:
+  exit_on_snapshot_boot: true
+
+# Logging
+log_level: "info"

--- a/configs/refind-btrfs-snapshots.yaml
+++ b/configs/refind-btrfs-snapshots.yaml
@@ -114,6 +114,16 @@ uki:
   #   "disable" - Generate the entry with rEFInd's 'disabled' directive (visible but not bootable)
   snapshot_strategy: "skip"
 
+# BLS Type #1 entry output (consumed by the bls-btrfs-snapshots binary).
+# rEFInd does NOT read these; refind-btrfs-snapshots ignores this block.
+# Disabled by default. Only ESP-mode snapshots are emitted — systemd-boot
+# and BLS-GRUB cannot traverse btrfs subvolumes to reach kernels inside a
+# snapshot. See https://uapi-group.org/specifications/specs/boot_loader_specification/
+bls:
+  write_entries: false
+  entries_dir: "/loader/entries"
+  entry_prefix: "bls-btrfs-snapshots-"
+
 # Advanced Options
 advanced:
   # Snapshot naming configuration

--- a/internal/bls/bootloader.go
+++ b/internal/bls/bootloader.go
@@ -1,0 +1,247 @@
+package bls
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bootloader"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
+	"github.com/rs/zerolog/log"
+)
+
+// NewGenerator returns the BLS Type #1 writer as a bootloader.Generator.
+// Its Generate is a no-op when cfg.BLS.WriteEntries is false.
+func NewGenerator() bootloader.Generator {
+	return &generator{}
+}
+
+type generator struct{}
+
+func (g *generator) Name() string { return "bls" }
+
+func (g *generator) Generate(input bootloader.Input) (*bootloader.Output, error) {
+	out := &bootloader.Output{}
+	if input.Cfg == nil || !input.Cfg.BLS.WriteEntries.IsTrue() {
+		return out, nil
+	}
+
+	cfg := input.Cfg.BLS
+	entriesDir := filepath.Join(input.ESPPath, cfg.EntriesDir)
+
+	expected, err := g.buildExpected(input, entriesDir, cfg.EntryPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	orphans, err := g.findOrphans(entriesDir, cfg.EntryPrefix, expected)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, d := range expected {
+		out.Diffs = append(out.Diffs, d)
+	}
+	for _, d := range orphans {
+		out.Diffs = append(out.Diffs, d)
+	}
+
+	if len(out.Diffs) > 0 {
+		out.UpdatedConfigs = append(out.UpdatedConfigs, cfg.EntriesDir)
+	}
+
+	log.Info().
+		Int("entries", len(expected)).
+		Int("orphans", len(orphans)).
+		Str("dir", entriesDir).
+		Msg("BLS entry generation complete")
+	return out, nil
+}
+
+// buildExpected emits one BLS entry per (source entry × eligible snapshot)
+// pair, following the same model the rEFInd generator uses: source entries
+// supply the loader/initrd/cmdline verbatim, snapshots are reachable when
+// at least one of their BootPlans is ESP-mode and not stale-delete.
+//
+// Returned map is keyed by absolute path for easy orphan diffing.
+func (g *generator) buildExpected(input bootloader.Input, entriesDir, prefix string) (map[string]*diff.FileDiff, error) {
+	expected := make(map[string]*diff.FileDiff)
+	if len(input.SourceEntries) == 0 {
+		return expected, nil
+	}
+
+	eligibleSnaps := eligibleSnapshots(input.BootPlans)
+	if len(eligibleSnaps) == 0 {
+		return expected, nil
+	}
+
+	for _, src := range input.SourceEntries {
+		if src.Loader == "" {
+			continue
+		}
+		titleSlug := slugify(src.Title)
+		if titleSlug == "" {
+			titleSlug = "entry"
+		}
+		for _, snap := range eligibleSnaps {
+			if snap == nil || snap.Subvolume == nil {
+				continue
+			}
+
+			entry := newEntryFromSource(snap, src, snapshotDisplayName(snap))
+			if entry == nil {
+				continue
+			}
+
+			id := fmt.Sprintf("%d-%s", snap.Subvolume.ID, titleSlug)
+			filename := EntryFilename(prefix, id)
+			abspath := filepath.Join(entriesDir, filename)
+
+			var body bytes.Buffer
+			if err := WriteEntry(&body, entry); err != nil {
+				return nil, fmt.Errorf("write BLS entry for %s: %w", id, err)
+			}
+
+			original := ""
+			isNew := true
+			if existing, err := os.ReadFile(abspath); err == nil {
+				original = string(existing)
+				isNew = false
+			}
+
+			expected[abspath] = &diff.FileDiff{
+				Path:     abspath,
+				Original: original,
+				Modified: body.String(),
+				IsNew:    isNew,
+			}
+		}
+	}
+	return expected, nil
+}
+
+// eligibleSnapshots returns deduplicated *btrfs.Snapshot pointers for
+// snapshots with at least one ESP-mode, non-UKI plan that isn't
+// stale-delete. Btrfs-mode plans are excluded because systemd-boot can't
+// traverse btrfs subvolumes to reach kernels inside the snapshot.
+func eligibleSnapshots(plans []*kernel.BootPlan) []*btrfs.Snapshot {
+	seen := make(map[string]bool, len(plans))
+	out := make([]*btrfs.Snapshot, 0, len(plans))
+	for _, p := range plans {
+		if p == nil || p.Snapshot == nil || p.Mode != kernel.BootModeESP {
+			continue
+		}
+		if p.Layout == kernel.LayoutUKI {
+			continue
+		}
+		if p.ShouldSkip() {
+			continue
+		}
+		if seen[p.Snapshot.Path] {
+			continue
+		}
+		seen[p.Snapshot.Path] = true
+		out = append(out, p.Snapshot)
+	}
+	return out
+}
+
+// newEntryFromSource builds a BLS Entry from a source entry's loader/initrd
+// plus the snapshot-targeted cmdline.
+func newEntryFromSource(snap *btrfs.Snapshot, src bootloader.SourceEntry, displayName string) *Entry {
+	if snap == nil || snap.Subvolume == nil || src.Loader == "" {
+		return nil
+	}
+	opts := rewriteCmdline(src.Options, snap)
+	e := &Entry{
+		Title:  fmt.Sprintf("%s (%s)", src.Title, displayName),
+		Sort:   fmt.Sprintf("bls-btrfs-snapshots-%d", snap.Subvolume.ID),
+		Linux:  src.Loader,
+		Initrd: append([]string(nil), src.Initrd...),
+	}
+	if opts != "" {
+		e.Options = []string{opts}
+	}
+	return e
+}
+
+// findOrphans returns FileDiff removals for any .conf in entriesDir that
+// matches our prefix but isn't in the expected set.
+func (g *generator) findOrphans(entriesDir, prefix string, expected map[string]*diff.FileDiff) ([]*diff.FileDiff, error) {
+	if prefix == "" {
+		// No prefix means we have no way to recognise our managed files;
+		// refusing to scan is safer than risking unrelated deletions.
+		return nil, nil
+	}
+	entries, err := os.ReadDir(entriesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read BLS entries dir: %w", err)
+	}
+
+	var orphans []*diff.FileDiff
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".conf") {
+			continue
+		}
+		abspath := filepath.Join(entriesDir, name)
+		if _, kept := expected[abspath]; kept {
+			continue
+		}
+		body, err := os.ReadFile(abspath)
+		if err != nil {
+			log.Warn().Err(err).Str("path", abspath).Msg("Could not read orphan BLS entry for diff")
+			continue
+		}
+		orphans = append(orphans, &diff.FileDiff{
+			Path:     abspath,
+			Original: string(body),
+			Modified: "",
+		})
+	}
+	return orphans, nil
+}
+
+// snapshotDisplayName matches the rEFInd generator's snapshot display
+// convention so labels read the same across both binaries.
+func snapshotDisplayName(snap *btrfs.Snapshot) string {
+	if snap == nil {
+		return ""
+	}
+	return snap.SnapshotTime.UTC().Format(time.RFC3339)
+}
+
+// slugify produces a filesystem-friendly identifier from a free-form title:
+// lowercase, alnum + dashes only, runs of separators collapsed.
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	out := make([]rune, 0, len(s))
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			out = append(out, r)
+			prevDash = false
+		default:
+			if !prevDash && len(out) > 0 {
+				out = append(out, '-')
+				prevDash = true
+			}
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	return string(out)
+}

--- a/internal/bls/bootloader.go
+++ b/internal/bls/bootloader.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bootloader"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
@@ -93,7 +92,7 @@ func (g *generator) buildExpected(input bootloader.Input, entriesDir, prefix str
 				continue
 			}
 
-			entry := newEntryFromSource(snap, src, snapshotDisplayName(snap))
+			entry := newEntryFromSource(snap, src, snapshotDisplayName(snap, input.Cfg.Advanced.Naming.MenuFormat, input.Cfg.Display.LocalTime.IsTrue()))
 			if entry == nil {
 				continue
 			}
@@ -213,13 +212,21 @@ func (g *generator) findOrphans(entriesDir, prefix string, expected map[string]*
 	return orphans, nil
 }
 
-// snapshotDisplayName matches the rEFInd generator's snapshot display
-// convention so labels read the same across both binaries.
-func snapshotDisplayName(snap *btrfs.Snapshot) string {
+// snapshotDisplayName mirrors the rEFInd generator's getSnapshotDisplayName
+// so labels read the same across both binaries: rwsnap_<ts>_<id> directory
+// names yield the embedded timestamp; everything else formats SnapshotTime
+// through the user's menu_format + local_time settings.
+func snapshotDisplayName(snap *btrfs.Snapshot, menuFormat string, useLocalTime bool) string {
 	if snap == nil {
 		return ""
 	}
-	return snap.SnapshotTime.UTC().Format(time.RFC3339)
+	if base := filepath.Base(snap.Path); strings.HasPrefix(base, "rwsnap_") {
+		parts := strings.Split(base, "_")
+		if len(parts) >= 3 {
+			return strings.Join(parts[1:len(parts)-1], "_")
+		}
+	}
+	return btrfs.FormatSnapshotTimeForMenu(snap.SnapshotTime, menuFormat, useLocalTime)
 }
 
 // slugify produces a filesystem-friendly identifier from a free-form title:

--- a/internal/bls/bootloader.go
+++ b/internal/bls/bootloader.go
@@ -46,9 +46,7 @@ func (g *generator) Generate(input bootloader.Input) (*bootloader.Output, error)
 	for _, d := range expected {
 		out.Diffs = append(out.Diffs, d)
 	}
-	for _, d := range orphans {
-		out.Diffs = append(out.Diffs, d)
-	}
+	out.Diffs = append(out.Diffs, orphans...)
 
 	if len(out.Diffs) > 0 {
 		out.UpdatedConfigs = append(out.UpdatedConfigs, cfg.EntriesDir)

--- a/internal/bls/bootloader_test.go
+++ b/internal/bls/bootloader_test.go
@@ -213,3 +213,45 @@ func TestBLSGenerator_NameAndUpdatedConfigs(t *testing.T) {
 	require.NotEmpty(t, out.UpdatedConfigs, "UpdatedConfigs should list the entries dir")
 	assert.Contains(t, out.UpdatedConfigs[0], "/loader/entries")
 }
+
+func TestSnapshotDisplayName(t *testing.T) {
+	ts := time.Date(2026, 5, 27, 16, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		path         string
+		menuFormat   string
+		useLocalTime bool
+		want         string
+	}{
+		{
+			name:       "default_menu_format_utc",
+			path:       "/.snapshots/8064/snapshot",
+			menuFormat: "2006-01-02T15:04:05Z",
+			want:       "2026-05-27T16:00:00Z",
+		},
+		{
+			name:       "custom_menu_format_friendly_placeholders",
+			path:       "/.snapshots/8064/snapshot",
+			menuFormat: "YYYY/MM/DD HH:mm",
+			want:       "2026/05/27 16:00",
+		},
+		{
+			name:       "rwsnap_prefix_extracts_embedded_timestamp",
+			path:       "/.snapshots/rwsnap_2026-05-27T16-00-00_42",
+			menuFormat: "2006-01-02T15:04:05Z",
+			want:       "2026-05-27T16-00-00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snap := &btrfs.Snapshot{
+				Subvolume:    &btrfs.Subvolume{ID: 42, Path: tt.path},
+				SnapshotTime: ts,
+			}
+			got := snapshotDisplayName(snap, tt.menuFormat, tt.useLocalTime)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/bls/bootloader_test.go
+++ b/internal/bls/bootloader_test.go
@@ -1,0 +1,215 @@
+package bls
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/bootloader"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/config"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Documented contract:
+//   - Generate returns empty Output when Cfg.BLS.WriteEntries is false (no-op).
+//   - Generate returns one new-file FileDiff per eligible BootPlan.
+//   - Existing on-disk files matching the prefix that aren't in the expected
+//     set are returned as removal FileDiffs (Modified="", Original=content).
+//   - Files outside the prefix are untouched, even in the same directory.
+//   - Output.UpdatedConfigs lists the entries dir so the run summary
+//     surfaces the change.
+
+func espCfg(write bool, dir, prefix string) *config.Config {
+	return &config.Config{
+		BLS: config.BLSConfig{
+			WriteEntries: config.Truthy(write),
+			EntriesDir:   dir,
+			EntryPrefix:  prefix,
+		},
+	}
+}
+
+func makeBootPlan(snapPath string, id uint64, kernelName string) *kernel.BootPlan {
+	return &kernel.BootPlan{
+		Snapshot: &btrfs.Snapshot{
+			Subvolume:    &btrfs.Subvolume{ID: id, Path: snapPath},
+			SnapshotTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Mode:   kernel.BootModeESP,
+		Layout: kernel.LayoutSplit,
+		BootSet: &kernel.BootSet{
+			KernelName: kernelName,
+			Layout:     kernel.LayoutSplit,
+			Kernel: &kernel.BootImage{
+				Path:     "/vmlinuz-" + kernelName,
+				Filename: "vmlinuz-" + kernelName,
+				Role:     kernel.RoleKernel,
+			},
+			Initramfs: &kernel.BootImage{
+				Path:     "/initramfs-" + kernelName + ".img",
+				Filename: "initramfs-" + kernelName + ".img",
+				Role:     kernel.RoleInitramfs,
+			},
+		},
+	}
+}
+
+func TestBLSGenerator_DisabledByDefault(t *testing.T) {
+	espDir := t.TempDir()
+	input := bootloader.Input{
+		Cfg:       espCfg(false, "/loader/entries", "bls-btrfs-snapshots-"),
+		ESPPath:   espDir,
+		BootPlans: []*kernel.BootPlan{makeBootPlan("@/.snapshots/73/snapshot", 256, "linux")},
+		SourceEntries: []bootloader.SourceEntry{
+			{Title: "Arch Linux", Loader: "/vmlinuz-linux", Options: "root=UUID=x rw"},
+		},
+	}
+
+	out, err := NewGenerator().Generate(input)
+	require.NoError(t, err)
+	assert.Empty(t, out.Diffs, "WriteEntries=false must produce no diffs")
+}
+
+func TestBLSGenerator_EmitsEntryPerEligiblePlan(t *testing.T) {
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "loader", "entries"), 0o755))
+
+	plan := makeBootPlan("@/.snapshots/73/snapshot", 256, "linux")
+	input := bootloader.Input{
+		Cfg:       espCfg(true, "/loader/entries", "bls-btrfs-snapshots-"),
+		ESPPath:   espDir,
+		BootPlans: []*kernel.BootPlan{plan},
+		SourceEntries: []bootloader.SourceEntry{
+			{Title: "Arch Linux", Loader: "/vmlinuz-linux", Options: "root=UUID=x rw rootflags=subvol=@"},
+		},
+	}
+
+	out, err := NewGenerator().Generate(input)
+	require.NoError(t, err)
+	require.Len(t, out.Diffs, 1, "expected one BLS entry diff")
+
+	d := out.Diffs[0]
+	assert.True(t, d.IsNew, "new entry should be marked IsNew")
+	assert.Equal(t, "", d.Original)
+	assert.Contains(t, d.Path, "bls-btrfs-snapshots-")
+	assert.True(t, strings.HasSuffix(d.Path, ".conf"))
+	assert.Contains(t, d.Modified, "linux /vmlinuz-linux")
+	assert.Contains(t, d.Modified, "subvol=@/.snapshots/73/snapshot")
+	assert.Contains(t, d.Modified, "subvolid=256")
+}
+
+func TestBLSGenerator_SkipsBtrfsModePlans(t *testing.T) {
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "loader", "entries"), 0o755))
+
+	plan := makeBootPlan("@/.snapshots/42/snapshot", 101, "linux")
+	plan.Mode = kernel.BootModeBtrfs
+
+	input := bootloader.Input{
+		Cfg:       espCfg(true, "/loader/entries", "bls-btrfs-snapshots-"),
+		ESPPath:   espDir,
+		BootPlans: []*kernel.BootPlan{plan},
+		SourceEntries: []bootloader.SourceEntry{
+			{Title: "Arch Linux", Loader: "/vmlinuz-linux", Options: "root=UUID=x rw"},
+		},
+	}
+
+	out, err := NewGenerator().Generate(input)
+	require.NoError(t, err)
+	assert.Empty(t, out.Diffs, "btrfs-mode plans must not produce BLS entries")
+}
+
+func TestBLSGenerator_OrphanCleanup(t *testing.T) {
+	espDir := t.TempDir()
+	entriesDir := filepath.Join(espDir, "loader", "entries")
+	require.NoError(t, os.MkdirAll(entriesDir, 0o755))
+
+	// Plant three managed files: one we still want (256, the current snapshot
+	// with the same source-title slug we'd produce), two orphans (50, 99).
+	planted := map[string]string{
+		"bls-btrfs-snapshots-256-arch-linux.conf": "title old\nlinux /old\n",
+		"bls-btrfs-snapshots-50-arch-linux.conf":  "title orphan\nlinux /orphan\n",
+		"bls-btrfs-snapshots-99-arch-linux.conf":  "title orphan2\nlinux /orphan2\n",
+		// Unrelated file (not our prefix) — must be untouched.
+		"arch.conf": "title Arch\nlinux /vmlinuz-linux\n",
+	}
+	for name, body := range planted {
+		require.NoError(t, os.WriteFile(filepath.Join(entriesDir, name), []byte(body), 0o644))
+	}
+
+	plan := makeBootPlan("@/.snapshots/73/snapshot", 256, "linux")
+	input := bootloader.Input{
+		Cfg:       espCfg(true, "/loader/entries", "bls-btrfs-snapshots-"),
+		ESPPath:   espDir,
+		BootPlans: []*kernel.BootPlan{plan},
+		SourceEntries: []bootloader.SourceEntry{
+			{Title: "Arch Linux", Loader: "/vmlinuz-linux", Options: "root=UUID=x rw"},
+		},
+	}
+
+	out, err := NewGenerator().Generate(input)
+	require.NoError(t, err)
+
+	// Categorise diffs by op.
+	var updates, removals []*string
+	for _, d := range out.Diffs {
+		path := d.Path
+		if d.Modified == "" && d.Original != "" {
+			removals = append(removals, &path)
+		} else {
+			updates = append(updates, &path)
+		}
+	}
+
+	assert.Len(t, removals, 2, "two orphan removals expected: %v", removals)
+	assert.Len(t, updates, 1, "one update for the current snapshot")
+
+	// arch.conf must NOT appear anywhere — it's outside our prefix.
+	for _, d := range out.Diffs {
+		assert.NotContains(t, d.Path, "arch.conf",
+			"non-prefixed files must not be touched")
+	}
+}
+
+func TestBLSGenerator_NoSourceEntryNoEmit(t *testing.T) {
+	// If there's no source entry to derive the cmdline from, we have
+	// nothing meaningful to write — skip rather than emit a broken entry.
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "loader", "entries"), 0o755))
+
+	plan := makeBootPlan("@/.snapshots/73/snapshot", 256, "linux")
+	input := bootloader.Input{
+		Cfg:           espCfg(true, "/loader/entries", "bls-btrfs-snapshots-"),
+		ESPPath:       espDir,
+		BootPlans:     []*kernel.BootPlan{plan},
+		SourceEntries: nil, // <-- no sources
+	}
+
+	out, err := NewGenerator().Generate(input)
+	require.NoError(t, err)
+	assert.Empty(t, out.Diffs, "no source entries → no BLS output")
+}
+
+func TestBLSGenerator_NameAndUpdatedConfigs(t *testing.T) {
+	g := NewGenerator()
+	assert.Equal(t, "bls", g.Name())
+
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "loader", "entries"), 0o755))
+	out, err := g.Generate(bootloader.Input{
+		Cfg:       espCfg(true, "/loader/entries", "bls-btrfs-snapshots-"),
+		ESPPath:   espDir,
+		BootPlans: []*kernel.BootPlan{makeBootPlan("@/.snapshots/73/snapshot", 256, "linux")},
+		SourceEntries: []bootloader.SourceEntry{
+			{Title: "Arch Linux", Loader: "/vmlinuz-linux", Options: "root=UUID=x rw"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.UpdatedConfigs, "UpdatedConfigs should list the entries dir")
+	assert.Contains(t, out.UpdatedConfigs[0], "/loader/entries")
+}

--- a/internal/bls/snapshot.go
+++ b/internal/bls/snapshot.go
@@ -1,0 +1,33 @@
+package bls
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/params"
+)
+
+// rewriteCmdline substitutes the snapshot's subvol path and subvolid into
+// baseCmdline. Preserves the user's @ vs /@ subvolume-format preference.
+func rewriteCmdline(baseCmdline string, snap *btrfs.Snapshot) string {
+	if baseCmdline == "" {
+		return ""
+	}
+	p := params.NewBootOptionsParser()
+
+	rootflags := p.ExtractRootFlags(baseCmdline)
+	originalSubvol := p.ExtractSubvol(rootflags)
+
+	pathPart := strings.TrimPrefix(snap.Path, "@")
+	var snapshotSubvol string
+	if originalSubvol != "" && strings.HasPrefix(originalSubvol, "/@") {
+		snapshotSubvol = "/@" + pathPart
+	} else {
+		snapshotSubvol = "@" + pathPart
+	}
+
+	out := p.UpdateSubvol(baseCmdline, snapshotSubvol)
+	out = p.UpdateSubvolID(out, fmt.Sprintf("%d", snap.ID))
+	return out
+}

--- a/internal/bls/snapshot_test.go
+++ b/internal/bls/snapshot_test.go
@@ -1,0 +1,56 @@
+package bls
+
+import (
+	"testing"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func snap(id uint64, path string) *btrfs.Snapshot {
+	return &btrfs.Snapshot{Subvolume: &btrfs.Subvolume{ID: id, Path: path}}
+}
+
+func TestRewriteCmdline(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		snap *btrfs.Snapshot
+		want string
+	}{
+		{
+			name: "empty_base_returns_empty",
+			base: "",
+			snap: snap(256, "@/.snapshots/1/snapshot"),
+			want: "",
+		},
+		{
+			name: "preserves_bare_at_prefix",
+			base: "root=UUID=x rw rootflags=subvol=@,subvolid=5",
+			snap: snap(256, "@/.snapshots/1/snapshot"),
+			want: "root=UUID=x rw rootflags=subvol=@/.snapshots/1/snapshot,subvolid=256",
+		},
+		{
+			name: "preserves_slash_at_prefix",
+			base: "root=UUID=x rw rootflags=subvol=/@,subvolid=5",
+			snap: snap(256, "@/.snapshots/1/snapshot"),
+			want: "root=UUID=x rw rootflags=subvol=/@/.snapshots/1/snapshot,subvolid=256",
+		},
+		{
+			name: "adds_rootflags_when_missing",
+			base: "root=UUID=x rw quiet",
+			snap: snap(42, "@/.snapshots/9/snapshot"),
+			// First call adds rootflags=subvol=…; second call finds the
+			// rootflags= the first added and merges subvolid= into it
+			// comma-separated, so we end up with one combined rootflags=.
+			want: "root=UUID=x rw quiet rootflags=subvol=@/.snapshots/9/snapshot,subvolid=42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteCmdline(tt.base, tt.snap)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/bls/writer.go
+++ b/internal/bls/writer.go
@@ -1,0 +1,80 @@
+package bls
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// WriteEntry serialises a Type #1 entry. Keys appear in canonical order so
+// diffs against on-disk files are deterministic across runs.
+func WriteEntry(w io.Writer, e *Entry) error {
+	if err := writeKey(w, "title", e.Title); err != nil {
+		return err
+	}
+	if err := writeKey(w, "version", e.Version); err != nil {
+		return err
+	}
+	if err := writeKey(w, "machine-id", e.MachineID); err != nil {
+		return err
+	}
+	if err := writeKey(w, "sort-key", e.Sort); err != nil {
+		return err
+	}
+	if err := writeKey(w, "architecture", e.Architecture); err != nil {
+		return err
+	}
+	if err := writeKey(w, "linux", e.Linux); err != nil {
+		return err
+	}
+	for _, i := range e.Initrd {
+		if err := writeKey(w, "initrd", i); err != nil {
+			return err
+		}
+	}
+	if err := writeKey(w, "efi", e.EFI); err != nil {
+		return err
+	}
+	if err := writeKey(w, "devicetree", e.Devicetree); err != nil {
+		return err
+	}
+	for _, d := range e.DevicetreeOverlay {
+		if err := writeKey(w, "devicetree-overlay", d); err != nil {
+			return err
+		}
+	}
+	for _, o := range e.Options {
+		if err := writeKey(w, "options", o); err != nil {
+			return err
+		}
+	}
+	for k, v := range e.Extra {
+		if err := writeKey(w, k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeKey(w io.Writer, key, value string) error {
+	if value == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "%s %s\n", key, value)
+	return err
+}
+
+// EntryFilename returns "<prefix><sanitised-id>.conf". Spaces in id become
+// dashes so filenames stay shell-safe; the spec doesn't forbid spaces but
+// they cause friction with most tooling.
+func EntryFilename(prefix, id string) string {
+	sanitised := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ':
+			return '-'
+		default:
+			return r
+		}
+	}, id)
+	return prefix + sanitised + ".conf"
+}

--- a/internal/bls/writer_test.go
+++ b/internal/bls/writer_test.go
@@ -1,0 +1,153 @@
+package bls
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Documented contract:
+//   - WriteEntry emits a BLS Type #1 .conf body parseable by Parse().
+//     Round-trip equality on the spec-defined fields.
+//   - Keys appear in a stable canonical order so diffs against the file
+//     on disk are deterministic.
+//   - Multi-value keys (initrd, options, devicetree-overlay) emit one line
+//     per value.
+//   - EntryFilename returns "<prefix><id>.conf" — Entry.ID is the basis,
+//     never a user-supplied title (which may contain spaces / specials).
+
+func TestWriteEntry_RoundTripsThroughParser(t *testing.T) {
+	in := &Entry{
+		Title:        "Arch Linux (snapshot 2025-02-14T10:00:00Z)",
+		Version:      "6.19.0-2-cachyos",
+		MachineID:    "abcdef0123456789abcdef0123456789",
+		Sort:         "bls-btrfs-snapshots-256",
+		Linux:        "/vmlinuz-linux-cachyos",
+		Initrd:       []string{"/amd-ucode.img", "/initramfs-linux-cachyos.img"},
+		Options:      []string{"root=UUID=test-uuid rw quiet rootflags=subvol=/@/.snapshots/73/snapshot,subvolid=256"},
+		Architecture: "x64",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteEntry(&buf, in))
+
+	out, err := Parse(&buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, in.Title, out.Title)
+	assert.Equal(t, in.Version, out.Version)
+	assert.Equal(t, in.MachineID, out.MachineID)
+	assert.Equal(t, in.Sort, out.Sort)
+	assert.Equal(t, in.Linux, out.Linux)
+	assert.Equal(t, in.Architecture, out.Architecture)
+	assert.Equal(t, in.Initrd, out.Initrd)
+	assert.Equal(t, in.OptionsString(), out.OptionsString())
+}
+
+func TestWriteEntry_CanonicalKeyOrder(t *testing.T) {
+	// Same logical content emitted in canonical order: title, version,
+	// machine-id, sort-key, architecture, linux, initrd*, options, then
+	// extras (devicetree, devicetree-overlay*, efi, custom). Stable
+	// order means diff-on-disk is deterministic across runs.
+	e := &Entry{
+		Architecture: "x64",
+		Options:      []string{"root=UUID=x rw"},
+		Initrd:       []string{"/initrd.img"},
+		Linux:        "/vmlinuz",
+		MachineID:    "m",
+		Sort:         "s",
+		Title:        "T",
+		Version:      "V",
+	}
+	var buf bytes.Buffer
+	require.NoError(t, WriteEntry(&buf, e))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	// Find the index of each key; assert ascending.
+	indexOf := func(key string) int {
+		for i, l := range lines {
+			if strings.HasPrefix(l, key+" ") || strings.HasPrefix(l, key+"\t") {
+				return i
+			}
+		}
+		return -1
+	}
+	wantOrder := []string{"title", "version", "machine-id", "sort-key", "architecture", "linux", "initrd", "options"}
+	prev := -1
+	for _, key := range wantOrder {
+		idx := indexOf(key)
+		require.GreaterOrEqual(t, idx, 0, "missing key %q in output:\n%s", key, buf.String())
+		assert.Greater(t, idx, prev, "key %q out of order (idx=%d, previous=%d)\noutput:\n%s", key, idx, prev, buf.String())
+		prev = idx
+	}
+}
+
+func TestWriteEntry_MultipleInitrds(t *testing.T) {
+	e := &Entry{
+		Title:  "Linux",
+		Linux:  "/vmlinuz",
+		Initrd: []string{"/intel-ucode.img", "/amd-ucode.img", "/initramfs-linux.img"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, WriteEntry(&buf, e))
+
+	body := buf.String()
+	assert.Equal(t, 3, strings.Count(body, "\ninitrd ")+strings.Count(body, "^initrd "),
+		"expected 3 initrd lines in:\n%s", body)
+}
+
+func TestWriteEntry_DeterministicOutput(t *testing.T) {
+	// Identical input → identical bytes, across runs. Important for the
+	// patch/diff machinery — drift here causes spurious diffs.
+	e := &Entry{
+		Title:   "T",
+		Version: "V",
+		Linux:   "/vmlinuz",
+		Initrd:  []string{"/a.img", "/b.img"},
+		Options: []string{"root=UUID=x rw"},
+	}
+	var a, b bytes.Buffer
+	require.NoError(t, WriteEntry(&a, e))
+	require.NoError(t, WriteEntry(&b, e))
+	assert.Equal(t, a.String(), b.String())
+}
+
+func TestWriteEntry_OmitsEmptyFields(t *testing.T) {
+	// A minimal Entry should produce only the keys that have values —
+	// no empty `version` or `machine-id` lines polluting the file.
+	e := &Entry{
+		Title: "Minimal",
+		Linux: "/vmlinuz",
+	}
+	var buf bytes.Buffer
+	require.NoError(t, WriteEntry(&buf, e))
+
+	out := buf.String()
+	assert.NotContains(t, out, "version")
+	assert.NotContains(t, out, "machine-id")
+	assert.NotContains(t, out, "sort-key")
+	assert.NotContains(t, out, "architecture")
+	assert.NotContains(t, out, "initrd")
+	assert.NotContains(t, out, "options")
+	assert.Contains(t, out, "title Minimal")
+	assert.Contains(t, out, "linux /vmlinuz")
+}
+
+func TestEntryFilename(t *testing.T) {
+	cases := []struct {
+		prefix string
+		id     string
+		want   string
+	}{
+		{"bls-btrfs-snapshots-", "256", "bls-btrfs-snapshots-256.conf"},
+		{"", "arch-rolling", "arch-rolling.conf"},
+		{"bls-btrfs-snapshots-", "snapshot 2025", "bls-btrfs-snapshots-snapshot-2025.conf"},
+	}
+	for _, c := range cases {
+		got := EntryFilename(c.prefix, c.id)
+		assert.Equal(t, c.want, got, "prefix=%q id=%q", c.prefix, c.id)
+	}
+}

--- a/internal/bootloader/bootloader.go
+++ b/internal/bootloader/bootloader.go
@@ -1,0 +1,44 @@
+// Package bootloader is the interface boundary between the snapshot
+// discovery pipeline and per-bootloader emitters. Implementations consume
+// a primitive-typed Input and return file diffs; they must not touch disk
+// themselves — the pipeline applies the patch via the runner so dry-run
+// and confirmation flows stay uniform across bootloaders.
+package bootloader
+
+import (
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/config"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/kernel"
+)
+
+type Generator interface {
+	Name() string
+	Generate(input Input) (*Output, error)
+}
+
+// Input carries every field any current or anticipated generator might
+// need. Each implementation reads only what's relevant. SourceEntries
+// originates from whatever native boot config the system already has
+// (rEFInd menuentries today) and supplies the canonical cmdline/loader
+// paths used to derive snapshot variants.
+type Input struct {
+	Cfg                *config.Config
+	ESPPath            string
+	RootFS             *btrfs.Filesystem
+	ProcessedSnapshots []*btrfs.Snapshot
+	BootPlans          []*kernel.BootPlan
+	SourceEntries      []SourceEntry
+}
+
+type SourceEntry struct {
+	Title   string
+	Loader  string
+	Initrd  []string
+	Options string
+}
+
+type Output struct {
+	Diffs          []*diff.FileDiff
+	UpdatedConfigs []string
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	Behavior BehaviorConfig `koanf:"behavior"`
 	Kernel   KernelConfig   `koanf:"kernel"`
 	UKI      UKIConfig      `koanf:"uki"`
+	BLS      BLSConfig      `koanf:"bls"`
 	Display  DisplayConfig  `koanf:"display"`
 	Advanced AdvancedConfig `koanf:"advanced"`
 	List     ListConfig     `koanf:"list"`
@@ -61,6 +62,15 @@ type PatternConfig struct {
 
 type DisplayConfig struct {
 	LocalTime Truthy `koanf:"local_time"`
+}
+
+// BLSConfig: optional BLS Type #1 entry output, consumed by the bls-btrfs-snapshots
+// binary. rEFInd does not read these. Only ESP-mode snapshots emit — systemd-boot
+// and BLS-GRUB cannot traverse btrfs subvolumes.
+type BLSConfig struct {
+	WriteEntries Truthy `koanf:"write_entries"`
+	EntriesDir   string `koanf:"entries_dir"`
+	EntryPrefix  string `koanf:"entry_prefix"`
 }
 
 // UKIConfig.SnapshotStrategy: see docs/USAGE.md "UKI Snapshots: ESP-mode Caveat".

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -30,6 +30,11 @@ func Defaults() Config {
 		UKI: UKIConfig{
 			SnapshotStrategy: "skip",
 		},
+		BLS: BLSConfig{
+			WriteEntries: Truthy(false),
+			EntriesDir:   "/loader/entries",
+			EntryPrefix:  "bls-btrfs-snapshots-",
+		},
 		Advanced: AdvancedConfig{
 			Naming: NamingConfig{
 				RwsnapFormat: "2006-01-02_15-04-05",


### PR DESCRIPTION
## Summary

Adds a sibling binary `bls-btrfs-snapshots` that emits Boot Loader Specification Type #1 entries under `<esp>/loader/entries/`, consumed by systemd-boot and BLS-aware GRUB. Complements (does not depend on) the existing rEFInd binary — users on systemd-boot can use this without installing rEFInd; users on rEFInd keep using `refind-btrfs-snapshots`.

This PR builds on top of the cmd-layout / cliconfig / internal/version / BootSet-visibility work that just merged into main (PR #8).

## Three commits

1. **`8d75285`** `feat(bls): scaffold BLS Type #1 writer for bls-btrfs-snapshots binary` — Generator interface in `internal/bootloader`, BLSConfig schema, annotated config block.
2. **`055f067`** `feat(bls): implement BLS Type #1 writer + bls-btrfs-snapshots binary` — full library (`internal/bls`: writer, snapshot cmdline rewriter, bootloader Generator, orphan cleanup) + binary scaffolding + 19 tests.
3. **`85221bc`** `refactor(bls): self-contained binary — drop refind dependency, adopt shared helpers` — drops the v1 rEFInd-config-parsing coupling, switches to a self-contained source-entry discovery (existing BLS entries on ESP → `/etc/kernel/cmdline` → `/proc/cmdline`), and adopts the shared `cliconfig` + `internal/version` helpers from main.

## Design notes

- **Source-entry model:** same source-driven emission as the rEFInd binary (iterate per source × eligible snapshot, rewrite cmdline per snapshot), but reads templates from BLS `.conf` files instead of rEFInd's `loader` stanzas. No coupling to rEFInd; works on a system that has never seen rEFInd.
- **Eligibility:** ESP-mode, non-UKI layout, non-stale-delete. UKI snapshots are excluded because the cmdline lives embedded in the signed PE image and can't be rewritten by appending `rootflags`.
- **Orphan cleanup:** entries matching the managed prefix (`bls-btrfs-snapshots-` by default, configurable) that aren't in the current expected set get cleaned up automatically.
- **Opt-in:** `bls.write_entries: false` is the default so installing the binary alone produces no changes; users explicitly enable.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — all packages pass including:
  - `internal/bls`: 19 tests (writer, parser, generator, orphan cleanup, cmdline rewrite)
  - `cmd/bls-btrfs-snapshots`: 4 test groups (existing BLS entries / fallback / no-sources / strip proc cmdline)
- [x] Live `bls-btrfs-snapshots version` reads from `internal/version`
- [x] Live `sudo bls-btrfs-snapshots --config <tmp> generate --dry-run --yes` on a rEFInd-only host (no existing BLS entries):
  - Scanned `/boot/loader/entries` → 0 entries
  - Fell back to `/proc/cmdline`
  - Synthesised source from `linux-cachyos` BootSet
  - Generated 25 valid BLS entries with proper `rootflags=subvol=…,subvolid=…` substitution per snapshot
- [ ] CI `Test` passes
- [ ] CI `Build Check (amd64/arm64)` passes
- [ ] CI `Analyze (go)` passes
- [ ] codecov/patch passes (or close to baseline)

## What's next

- Phase 3 (future, separate branch): `uki-btrfs-snapshots` binary using `objcopy --update-section .cmdline=…` to clone+rewrite UKIs per snapshot. Secure Boot detect-and-refuse for v1; signing as opt-in v2.
- Phase 4 (deferred until demand): limine and/or grub-non-BLS — BLS-GRUB users are already covered by this PR.