### PR TITLE
refactor: extract internal/snapshotfs.UpdateSnapshotFstab + drop dead in-place writer

### DIFF
--- a/internal/fstab/fstab_test.go
+++ b/internal/fstab/fstab_test.go
@@ -6,11 +6,24 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
-	"github.com/jmylchreest/refind-btrfs-snapshots/internal/runner"
 )
+
+func createTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "fstab-test-*")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+	return f.Name()
+}
 
 func TestNewManager(t *testing.T) {
 	manager := NewManager()
@@ -747,175 +760,6 @@ func TestGetFieldOrDefault(t *testing.T) {
 	}
 }
 
-func TestManager_UpdateSnapshotFstab_DryRun(t *testing.T) {
-	// Create test data
-	snapshot := &btrfs.Snapshot{
-		Subvolume: &btrfs.Subvolume{
-			ID:   256,
-			Path: "/@snapshots/1/snapshot",
-		},
-		FilesystemPath: "/tmp/test-snapshot",
-	}
-
-	rootFS := &btrfs.Filesystem{
-		UUID: "test-uuid",
-	}
-
-	// Create temporary fstab
-	fstabContent := `UUID=test-uuid / btrfs subvol=@,defaults 0 1`
-	tmpDir := t.TempDir()
-	snapshotDir := filepath.Join(tmpDir, "snapshot")
-	etcDir := filepath.Join(snapshotDir, "etc")
-	if err := os.MkdirAll(etcDir, 0755); err != nil {
-		t.Fatalf("Failed to create test directory: %v", err)
-	}
-
-	fstabPath := filepath.Join(etcDir, "fstab")
-	if err := os.WriteFile(fstabPath, []byte(fstabContent), 0644); err != nil {
-		t.Fatalf("Failed to create test fstab: %v", err)
-	}
-
-	snapshot.FilesystemPath = snapshotDir
-
-	// Test dry run
-	r := runner.New(true) // dry run
-	manager := NewManager()
-	err := manager.UpdateSnapshotFstab(snapshot, rootFS, r)
-
-	if err != nil {
-		t.Errorf("UpdateSnapshotFstab() dry run error = %v", err)
-	}
-
-	// Verify file wasn't actually modified
-	content, err := os.ReadFile(fstabPath)
-	if err != nil {
-		t.Fatalf("Failed to read fstab after dry run: %v", err)
-	}
-
-	if string(content) != fstabContent {
-		t.Error("UpdateSnapshotFstab() dry run should not modify file")
-	}
-}
-
-// Helper function to create temporary files for testing
-func createTempFile(t *testing.T, content string) string {
-	tmpFile, err := os.CreateTemp("", "fstab_test_*")
-	if err != nil {
-		t.Fatalf("Failed to create temporary file: %v", err)
-	}
-
-	if _, err := tmpFile.WriteString(content); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
-		t.Fatalf("Failed to write to temporary file: %v", err)
-	}
-
-	tmpFile.Close()
-	return tmpFile.Name()
-}
-
-// Test real file operations with mock runner
-type mockRunner struct {
-	dryRun  bool
-	written map[string][]byte
-}
-
-func newMockRunner(dryRun bool) *mockRunner {
-	return &mockRunner{
-		dryRun:  dryRun,
-		written: make(map[string][]byte),
-	}
-}
-
-func (r *mockRunner) IsDryRun() bool {
-	return r.dryRun
-}
-
-func (r *mockRunner) WriteFile(path string, data []byte, perm os.FileMode, description string) error {
-	if r.dryRun {
-		return nil
-	}
-	r.written[path] = data
-	return nil
-}
-
-func (r *mockRunner) Command(name string, args []string, description string) error {
-	return nil
-}
-
-func (r *mockRunner) MkdirAll(path string, perm os.FileMode, description string) error {
-	return nil
-}
-
-func TestManager_UpdateSnapshotFstab_WithMockRunner(t *testing.T) {
-	snapshot := &btrfs.Snapshot{
-		Subvolume: &btrfs.Subvolume{
-			ID:   256,
-			Path: "/@snapshots/1/snapshot",
-		},
-		FilesystemPath: "/tmp/test-snapshot",
-		SnapshotTime:   time.Now(),
-	}
-
-	rootFS := &btrfs.Filesystem{
-		UUID: "test-uuid",
-	}
-
-	// Create temporary fstab
-	fstabContent := `# Test fstab
-UUID=test-uuid / btrfs subvol=@,defaults 0 1
-UUID=other /home btrfs defaults 0 2`
-
-	tmpDir := t.TempDir()
-	snapshotDir := filepath.Join(tmpDir, "snapshot")
-	etcDir := filepath.Join(snapshotDir, "etc")
-	if err := os.MkdirAll(etcDir, 0755); err != nil {
-		t.Fatalf("Failed to create test directory: %v", err)
-	}
-
-	fstabPath := filepath.Join(etcDir, "fstab")
-	if err := os.WriteFile(fstabPath, []byte(fstabContent), 0644); err != nil {
-		t.Fatalf("Failed to create test fstab: %v", err)
-	}
-
-	snapshot.FilesystemPath = snapshotDir
-
-	// Test with mock runner
-	r := newMockRunner(false)
-	manager := NewManager()
-	err := manager.UpdateSnapshotFstab(snapshot, rootFS, r)
-
-	if err != nil {
-		t.Errorf("UpdateSnapshotFstab() error = %v", err)
-		return
-	}
-
-	// Verify the file was written through the runner
-	writtenData, exists := r.written[fstabPath]
-	if !exists {
-		t.Error("UpdateSnapshotFstab() should have written fstab file through runner")
-		return
-	}
-
-	writtenContent := string(writtenData)
-	if !strings.Contains(writtenContent, "subvol=/@snapshots/1/snapshot") {
-		t.Error("UpdateSnapshotFstab() should update subvol option")
-	}
-
-	if !strings.Contains(writtenContent, "subvolid=256") {
-		t.Error("UpdateSnapshotFstab() should update subvolid option")
-	}
-
-	// Verify comments are preserved
-	if !strings.Contains(writtenContent, "# Test fstab") {
-		t.Error("UpdateSnapshotFstab() should preserve comments")
-	}
-
-	// Verify unrelated entries are preserved
-	if !strings.Contains(writtenContent, "UUID=other /home btrfs defaults 0 2") {
-		t.Error("UpdateSnapshotFstab() should preserve unrelated entries")
-	}
-}
 
 func TestManager_AnalyzeBootMount(t *testing.T) {
 	tests := []struct {

--- a/internal/fstab/snapshot.go
+++ b/internal/fstab/snapshot.go
@@ -9,14 +9,8 @@ import (
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/params"
-	"github.com/jmylchreest/refind-btrfs-snapshots/internal/runner"
 	"github.com/rs/zerolog/log"
 )
-
-// UpdateSnapshotFstab updates the fstab file in a snapshot to reflect the snapshot's subvolume
-func (m *Manager) UpdateSnapshotFstab(snapshot *btrfs.Snapshot, rootFS *btrfs.Filesystem, r runner.Runner) error {
-	return m.updateSnapshotFstab(snapshot, rootFS, r, false)
-}
 
 // UpdateSnapshotFstabDiff generates a diff for fstab changes without applying them
 func (m *Manager) UpdateSnapshotFstabDiff(snapshot *btrfs.Snapshot, rootFS *btrfs.Filesystem) (*diff.FileDiff, error) {
@@ -69,74 +63,6 @@ func (m *Manager) UpdateSnapshotFstabDiff(snapshot *btrfs.Snapshot, rootFS *btrf
 		Modified: newContent,
 		IsNew:    false,
 	}, nil
-}
-
-// updateSnapshotFstab updates the fstab file in a snapshot to reflect the snapshot's subvolume
-func (m *Manager) updateSnapshotFstab(snapshot *btrfs.Snapshot, rootFS *btrfs.Filesystem, r runner.Runner, askConfirmation bool) error {
-	fstabPath := btrfs.GetSnapshotFstabPath(snapshot)
-	log.Debug().Str("path", fstabPath).Str("snapshot", snapshot.Path).Msg("Updating snapshot fstab")
-
-	if _, err := os.Stat(fstabPath); errors.Is(err, os.ErrNotExist) {
-		log.Warn().Str("path", fstabPath).Msg("Fstab file does not exist in snapshot")
-		return nil
-	}
-
-	originalContent, err := os.ReadFile(fstabPath)
-	if err != nil {
-		return fmt.Errorf("failed to read original fstab: %w", err)
-	}
-
-	fstab, err := m.ParseFstab(fstabPath)
-	if err != nil {
-		return fmt.Errorf("failed to parse snapshot fstab: %w", err)
-	}
-
-	modified := false
-	modifiedEntries := make(map[string]bool)
-	for _, entry := range fstab.Entries {
-		if m.isRootMount(entry, rootFS) {
-			if m.updateRootEntry(entry, snapshot, rootFS) {
-				modified = true
-				modifiedEntries[entry.Original] = true
-			}
-		}
-	}
-
-	if !modified {
-		log.Debug().Str("path", fstabPath).Msg("No changes needed in fstab")
-		return nil
-	}
-
-	newContent, err := m.generateFstabContentWithModifications(fstab, modifiedEntries)
-	if err != nil {
-		return fmt.Errorf("failed to generate fstab content: %w", err)
-	}
-
-	fileDiff := &diff.FileDiff{
-		Path:     fstabPath,
-		Original: string(originalContent),
-		Modified: newContent,
-		IsNew:    false,
-	}
-
-	if r.IsDryRun() {
-		diff.ShowDiff(fileDiff)
-		log.Info().Str("path", fstabPath).Msg("[DRY RUN] Would update snapshot fstab")
-		return nil
-	}
-
-	if askConfirmation {
-		if !diff.ConfirmChanges(fileDiff, false) {
-			log.Info().Str("path", fstabPath).Msg("Skipped updating snapshot fstab (user declined)")
-			return nil
-		}
-	}
-
-	if err := m.writeFstabWithRunner(fstabPath, fstab, modifiedEntries, r); err != nil {
-		return fmt.Errorf("failed to write updated fstab: %w", err)
-	}
-
-	return nil
 }
 
 // isRootMount determines if an fstab entry is for the root filesystem

--- a/internal/fstab/writer.go
+++ b/internal/fstab/writer.go
@@ -3,19 +3,7 @@ package fstab
 import (
 	"fmt"
 	"strings"
-
-	"github.com/jmylchreest/refind-btrfs-snapshots/internal/runner"
 )
-
-// writeFstabWithRunner writes an fstab structure back to a file using runner, preserving formatting of unchanged lines
-func (m *Manager) writeFstabWithRunner(path string, fstab *Fstab, modifiedEntries map[string]bool, r runner.Runner) error {
-	content, err := m.generateFstabContentWithModifications(fstab, modifiedEntries)
-	if err != nil {
-		return fmt.Errorf("failed to generate fstab content: %w", err)
-	}
-
-	return r.WriteFile(path, []byte(content), 0644, fmt.Sprintf("Update snapshot fstab: %s", path))
-}
 
 // generateFstabContentWithModifications generates fstab content, only reformatting modified entries
 func (m *Manager) generateFstabContentWithModifications(fstab *Fstab, modifiedEntries map[string]bool) (string, error) {

--- a/internal/generator/build.go
+++ b/internal/generator/build.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
 	"github.com/jmylchreest/refind-btrfs-snapshots/internal/refind"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/snapshotfs"
 	"github.com/rs/zerolog/log"
 )
 
@@ -35,16 +36,9 @@ func (p *Pipeline) BuildPatch(plan *Plan) (*diff.PatchDiff, *OperationSummary, e
 		}
 	}
 
-	for _, snapshot := range plan.ProcessedSnapshots {
-		fileDiff, err := p.Fstab.UpdateSnapshotFstabDiff(snapshot, plan.RootFS)
-		if err != nil {
-			log.Warn().Err(err).Str("snapshot", snapshot.Path).Msg("Failed to update snapshot fstab")
-			continue
-		}
-		if fileDiff != nil {
-			patch.AddFile(fileDiff)
-			summary.UpdatedFstabs = append(summary.UpdatedFstabs, snapshot.Path+"/etc/fstab")
-		}
+	for _, u := range snapshotfs.UpdateFstabs(plan.ProcessedSnapshots, plan.RootFS, p.Fstab) {
+		patch.AddFile(u.Diff)
+		summary.UpdatedFstabs = append(summary.UpdatedFstabs, u.Snapshot.Path+"/etc/fstab")
 	}
 
 	refindParser := refind.NewParserWithScanner(p.ESPPath, p.KernelScanner)

--- a/internal/snapshotfs/fstab.go
+++ b/internal/snapshotfs/fstab.go
@@ -1,0 +1,53 @@
+// Package snapshotfs computes diffs that align in-snapshot filesystem state
+// (currently just /etc/fstab) with the snapshot's own subvolume. Helpers are
+// pure — callers apply diffs via the shared runner — so running twice on an
+// already-aligned snapshot produces zero diffs.
+package snapshotfs
+
+import (
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/diff"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/fstab"
+	"github.com/rs/zerolog/log"
+)
+
+// FstabUpdate pairs a snapshot with its fstab diff so callers can build a
+// summary log keyed off Snapshot.Path (the diff's filesystem path differs).
+type FstabUpdate struct {
+	Snapshot *btrfs.Snapshot
+	Diff     *diff.FileDiff
+}
+
+// UpdateSnapshotFstab returns the fstab diff for a single snapshot. The diff
+// is nil when no change is needed (idempotent). Errors here are returned, not
+// logged, so callers can decide how to handle a single failure.
+func UpdateSnapshotFstab(snap *btrfs.Snapshot, rootFS *btrfs.Filesystem, mgr *fstab.Manager) (*FstabUpdate, error) {
+	d, err := mgr.UpdateSnapshotFstabDiff(snap, rootFS)
+	if err != nil {
+		return nil, err
+	}
+	if d == nil {
+		return nil, nil
+	}
+	return &FstabUpdate{Snapshot: snap, Diff: d}, nil
+}
+
+// UpdateFstabs is a convenience wrapper that calls UpdateSnapshotFstab for
+// each snapshot. Per-snapshot errors are logged at warn and the loop
+// continues so one bad snapshot doesn't block the rest. Callers that need
+// custom error handling, ordering, or parallelism should iterate themselves
+// and call UpdateSnapshotFstab directly.
+func UpdateFstabs(snapshots []*btrfs.Snapshot, rootFS *btrfs.Filesystem, mgr *fstab.Manager) []FstabUpdate {
+	var out []FstabUpdate
+	for _, snap := range snapshots {
+		u, err := UpdateSnapshotFstab(snap, rootFS, mgr)
+		if err != nil {
+			log.Warn().Err(err).Str("snapshot", snap.Path).Msg("Failed to update snapshot fstab")
+			continue
+		}
+		if u != nil {
+			out = append(out, *u)
+		}
+	}
+	return out
+}

--- a/internal/snapshotfs/fstab_test.go
+++ b/internal/snapshotfs/fstab_test.go
@@ -1,0 +1,120 @@
+package snapshotfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/btrfs"
+	"github.com/jmylchreest/refind-btrfs-snapshots/internal/fstab"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeSnapshotWithFstab creates a snapshot rooted at dir/<id> with the
+// provided fstab content under etc/fstab, mirroring the on-disk layout
+// btrfs.GetSnapshotFstabPath expects.
+func makeSnapshotWithFstab(t *testing.T, parent string, id uint64, subvolPath, fstabContent string) *btrfs.Snapshot {
+	t.Helper()
+	snapDir := filepath.Join(parent, "snap-"+subvolPath)
+	require.NoError(t, os.MkdirAll(filepath.Join(snapDir, "etc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snapDir, "etc", "fstab"), []byte(fstabContent), 0o644))
+	return &btrfs.Snapshot{
+		Subvolume:      &btrfs.Subvolume{ID: id, Path: subvolPath},
+		SnapshotTime:   time.Date(2026, 5, 27, 16, 0, 0, 0, time.UTC),
+		FilesystemPath: snapDir,
+	}
+}
+
+func TestUpdateFstabs_ProducesDiffForUnalignedRoot(t *testing.T) {
+	dir := t.TempDir()
+	// The snapshot's fstab still references the live @ subvol; the helper
+	// should rewrite it to point at the snapshot's own subvolume.
+	snap := makeSnapshotWithFstab(t, dir, 256, "@/.snapshots/1/snapshot",
+		"UUID=test-uuid / btrfs subvol=@,subvolid=5 0 0\n")
+
+	rootFS := &btrfs.Filesystem{
+		Device:    "/dev/test",
+		UUID:      "test-uuid",
+		Subvolume: &btrfs.Subvolume{ID: 5, Path: "@"},
+	}
+
+	updates := UpdateFstabs([]*btrfs.Snapshot{snap}, rootFS, fstab.NewManager())
+	require.Len(t, updates, 1)
+	assert.Same(t, snap, updates[0].Snapshot)
+	require.NotNil(t, updates[0].Diff)
+	assert.Contains(t, updates[0].Diff.Modified, "subvol=/@/.snapshots/1/snapshot")
+	assert.Contains(t, updates[0].Diff.Modified, "subvolid=256")
+}
+
+func TestUpdateFstabs_NoDiffWhenAlreadyAligned(t *testing.T) {
+	dir := t.TempDir()
+	// fstab already points at the snapshot's own subvol — helper must produce
+	// nothing. This is the idempotency case: a second run after a successful
+	// apply must not re-emit changes.
+	snap := makeSnapshotWithFstab(t, dir, 256, "@/.snapshots/1/snapshot",
+		"UUID=test-uuid / btrfs subvol=/@/.snapshots/1/snapshot,subvolid=256 0 0\n")
+
+	rootFS := &btrfs.Filesystem{
+		Device:    "/dev/test",
+		UUID:      "test-uuid",
+		Subvolume: &btrfs.Subvolume{ID: 5, Path: "@"},
+	}
+
+	updates := UpdateFstabs([]*btrfs.Snapshot{snap}, rootFS, fstab.NewManager())
+	assert.Empty(t, updates, "aligned fstab must produce no update")
+}
+
+func TestUpdateFstabs_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	snap := makeSnapshotWithFstab(t, dir, 256, "@/.snapshots/1/snapshot",
+		"UUID=test-uuid / btrfs subvol=@,subvolid=5 0 0\n")
+
+	rootFS := &btrfs.Filesystem{
+		Device:    "/dev/test",
+		UUID:      "test-uuid",
+		Subvolume: &btrfs.Subvolume{ID: 5, Path: "@"},
+	}
+
+	mgr := fstab.NewManager()
+	first := UpdateFstabs([]*btrfs.Snapshot{snap}, rootFS, mgr)
+	require.Len(t, first, 1)
+
+	// Apply the change to disk and re-run — the second call must produce
+	// nothing because the file is now aligned.
+	require.NoError(t, os.WriteFile(filepath.Join(snap.FilesystemPath, "etc", "fstab"),
+		[]byte(first[0].Diff.Modified), 0o644))
+
+	second := UpdateFstabs([]*btrfs.Snapshot{snap}, rootFS, mgr)
+	assert.Empty(t, second, "second invocation after apply must be a no-op")
+}
+
+func TestUpdateFstabs_SkipsSnapshotsWithoutFstab(t *testing.T) {
+	dir := t.TempDir()
+	snapDir := filepath.Join(dir, "snap-noetc")
+	require.NoError(t, os.MkdirAll(snapDir, 0o755))
+	snap := &btrfs.Snapshot{
+		Subvolume:      &btrfs.Subvolume{ID: 256, Path: "@/.snapshots/1/snapshot"},
+		SnapshotTime:   time.Date(2026, 5, 27, 16, 0, 0, 0, time.UTC),
+		FilesystemPath: snapDir,
+	}
+	rootFS := &btrfs.Filesystem{UUID: "test-uuid", Subvolume: &btrfs.Subvolume{ID: 5, Path: "@"}}
+
+	updates := UpdateFstabs([]*btrfs.Snapshot{snap}, rootFS, fstab.NewManager())
+	assert.Empty(t, updates, "missing fstab must produce no update and no error")
+}
+
+func TestUpdateFstabs_OneBadSnapshotDoesNotBlockOthers(t *testing.T) {
+	dir := t.TempDir()
+	good := makeSnapshotWithFstab(t, dir, 256, "@/.snapshots/1/snapshot",
+		"UUID=test-uuid / btrfs subvol=@,subvolid=5 0 0\n")
+	// "Bad" snapshot has no FilesystemPath set — the underlying call will
+	// log a warn and continue.
+	bad := &btrfs.Snapshot{Subvolume: &btrfs.Subvolume{ID: 999, Path: "@/.snapshots/bad"}}
+
+	rootFS := &btrfs.Filesystem{UUID: "test-uuid", Subvolume: &btrfs.Subvolume{ID: 5, Path: "@"}}
+	updates := UpdateFstabs([]*btrfs.Snapshot{bad, good}, rootFS, fstab.NewManager())
+	require.Len(t, updates, 1, "good snapshot must still produce its update")
+	assert.Same(t, good, updates[0].Snapshot)
+}


### PR DESCRIPTION
## Summary

Lifts the per-snapshot fstab update from `internal/generator/build.go` into a new shared `internal/snapshotfs` package so the bls binary (PR #9) and future uki/limine binaries can use it without reaching into the refind-specific pipeline.

While extracting, removes ~80 lines of dead code: the apply-in-place `Manager.UpdateSnapshotFstab` and its private helpers have had zero production callers since `UpdateSnapshotFstabDiff` was added — every live path now goes through the diff-first flow.

## API

```go
// Per-snapshot primitive — errors returned for caller-decided handling.
func UpdateSnapshotFstab(snap *btrfs.Snapshot, rootFS *btrfs.Filesystem, mgr *fstab.Manager) (*FstabUpdate, error)

// Bulk wrapper — per-snapshot errors logged at warn, loop continues.
func UpdateFstabs(snapshots []*btrfs.Snapshot, rootFS *btrfs.Filesystem, mgr *fstab.Manager) []FstabUpdate
```

`FstabUpdate{Snapshot, Diff}` lets callers preserve the existing summary-log format (`snapshot.Path + "/etc/fstab"`) which the diff's `Path` field doesn't expose directly.

## Idempotency

The helper has no side effects — it returns diffs, the caller applies them. The underlying `UpdateSnapshotFstabDiff` returns `nil` when the fstab is already aligned. So running the helper twice on a successfully-applied state produces zero diffs. Explicit test: `TestUpdateFstabs_Idempotent`.

## Cleanup

| Removed | Why |
|---|---|
| `Manager.UpdateSnapshotFstab` (exported, apply-in-place) | 0 production callers |
| `Manager.updateSnapshotFstab` (private) | only called by the dead exported wrapper |
| `Manager.writeFstabWithRunner` | only called by the dead private wrapper |
| `runner` imports from `internal/fstab/{snapshot,writer}.go` | only used by removed code |
| `TestManager_UpdateSnapshotFstab_{DryRun,WithMockRunner}` (~170 lines) | testing removed code |

The fstab-rewriting logic underneath (subvol/subvolid update, comment preservation, unrelated-entry preservation) remains covered by `TestManager_UpdateSnapshotFstabDiff`. Net diff: -135 lines.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — all packages pass including new `internal/snapshotfs` (5 tests)
- [x] **Live parity vs main** — `sudo refind-btrfs-snapshots generate --dry-run --yes` produces byte-identical output (148 lines, after stripping timestamps/ANSI). `status` output also byte-identical.
- [ ] CI Build Check (amd64/arm64) passes
- [ ] CI Test (full suite + staticcheck) passes
- [ ] CodeQL passes

## Next

After this merges, `feat/bls-btrfs-snapshots` (PR #9) gets rebased onto the new main and the bls binary's `runGenerate` picks up `snapshotfs.UpdateFstabs` to align each snapshot's fstab before emitting BLS entries — closing the boot-correctness gap identified in the audit.