### PR TITLE
ci: ship bls systemd .path + .service units, scope tarball systemd by binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -125,7 +125,7 @@ jobs:
         goarch: [amd64, arm64]
         binary:
           - { name: refind-btrfs-snapshots, path: ./cmd/refind-btrfs-snapshots, config: configs/refind-btrfs-snapshots.yaml, systemd: true }
-          - { name: bls-btrfs-snapshots,    path: ./cmd/bls-btrfs-snapshots,    config: configs/bls-btrfs-snapshots.yaml,    systemd: false }
+          - { name: bls-btrfs-snapshots,    path: ./cmd/bls-btrfs-snapshots,    config: configs/bls-btrfs-snapshots.yaml,    systemd: true }
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -172,7 +172,8 @@ jobs:
           cp ${{ matrix.binary.config }} "$STAGE/configs/"
           cp LICENSE "$STAGE/"
           if [[ "${{ matrix.binary.systemd }}" == "true" ]]; then
-            cp -r systemd "$STAGE/"
+            mkdir -p "$STAGE/systemd"
+            cp systemd/${BIN}.* "$STAGE/systemd/"
           fi
 
           tar czf "dist/assets/${BIN}_${VER}_linux_${ARCH}.tar.gz" -C "$STAGE" .

--- a/systemd/bls-btrfs-snapshots.path
+++ b/systemd/bls-btrfs-snapshots.path
@@ -1,0 +1,19 @@
+[Unit]
+Description=Watch for btrfs snapshot changes
+Documentation=https://github.com/jmylchreest/refind-btrfs-snapshots
+ConditionPathExists=/.snapshots
+
+[Path]
+# Monitor the default snapshot directory for changes
+# Add additional PathChanged= lines for other snapshot directories
+PathChanged=/.snapshots
+# Example for multiple locations (uncomment as needed):
+# PathChanged=/run/timeshift/backup/timeshift-btrfs/snapshots
+# PathChanged=/snapshots
+
+# Wait 10 seconds after the last change before triggering
+TriggerLimitIntervalSec=10
+TriggerLimitBurst=1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/bls-btrfs-snapshots.service
+++ b/systemd/bls-btrfs-snapshots.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Generate BLS Type #1 boot entries for btrfs snapshots
+Documentation=https://github.com/jmylchreest/refind-btrfs-snapshots
+After=local-fs.target
+Before=snapper-boot.service
+ConditionPathExists=/usr/bin/bls-btrfs-snapshots
+ConditionPathExists=/etc/bls-btrfs-snapshots.yaml
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bls-btrfs-snapshots --config /etc/bls-btrfs-snapshots.yaml generate -y
+User=root
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=300
+SyslogIdentifier=bls-btrfs-snapshots
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Adds the bls binary's systemd trigger units (mirroring the refind pair) and tightens the release tarball so each binary only bundles its own units instead of the whole `systemd/` directory.

## New units

- `systemd/bls-btrfs-snapshots.path` — inotify watch on `/.snapshots/`, 10s debounce, triggers the service. Same structure as the refind `.path` unit.
- `systemd/bls-btrfs-snapshots.service` — oneshot, runs `bls-btrfs-snapshots --config /etc/bls-btrfs-snapshots.yaml generate -y` as root. Differences vs refind: drops the `-g` (`--generate-include`) flag (no analogue in bls). Keeps `Before=snapper-boot.service` for the same boot-snapshot-ordering reason.

## Workflow changes

- `systemd: true` for bls in the build matrix.
- Tarball staging changes `cp -r systemd` to `cp systemd/${BIN}.*` so each binary's tarball only contains its own units. Prevents cross-pollution.

## AUR unaffected

The release job's "Copy systemd units for AUR direct download" step still references `refind-btrfs-snapshots.{service,path}` explicitly, and the AUR PKGBUILD checksum grep is anchored to those filenames. No bls PKGBUILD exists, so bls is silently ignored by the AUR path.

## Test plan

- [x] Glob expansion verified locally: `refind-btrfs-snapshots.*` and `bls-btrfs-snapshots.*` each resolve to exactly the two relevant files.
- [x] YAML parses.
- [ ] CI build-check passes for refind + bls × amd64 + arm64
- [ ] Post-merge prerelease pipeline produces both binaries' tarballs with the right units bundled