### PR TITLE
docs: add WISHLIST.md (uki binary); correct existing UKI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,7 @@ Yes. If your system transitioned between boot configurations over time, older sn
 
 **Q: I use Unified Kernel Images (UKIs). Are they supported?**
 
-Yes — UKIs (BLS Type #2) are discovered and inspected automatically. Behaviour depends on where the UKI lives:
-
-- **Inside the snapshot's `/boot/EFI/Linux/`** (btrfs mode): fully supported. Each snapshot's UKI has its own embedded cmdline pointing at that snapshot.
-- **On the ESP** (`<esp>/EFI/Linux/`): the UKI's embedded cmdline points at the *live* root, and the systemd-stub ignores boot-loader-supplied cmdline on standard UKIs — so a snapshot boot entry would actually boot live root. By default we **skip** these (`uki.snapshot_strategy: skip`). Set to `warn` or `disable` if you'd rather see them in the menu. See [Boot Layouts](docs/USAGE.md#boot-layouts) for the full explanation.
+UKIs are **discovered and inspected** — they appear in `list bootsets`, `status`, and `kernel-spy`, and their embedded kernel version participates in staleness detection. We do **not** make snapshots bootable for UKI boot sets: a UKI's cmdline lives in its signed `.cmdline` PE section, and there's no general boot-loader-side override, so producing a snapshot boot entry would require rewriting (and re-signing under Secure Boot) the UKI per snapshot. That's tracked as a planned standalone `uki-btrfs-snapshots` binary — see [`docs/WISHLIST.md`](docs/WISHLIST.md).
 
 **Q: I use systemd-boot's BLS `.conf` files. Do they affect anything?**
 

--- a/configs/refind-btrfs-snapshots.yaml
+++ b/configs/refind-btrfs-snapshots.yaml
@@ -98,19 +98,17 @@ kernel:
 
 # Unified Kernel Image (UKI) handling
 #
-# A UKI (BLS Type #2) is a single PE/EFI binary containing kernel + initramfs +
-# cmdline. The systemd-stub ignores boot-loader-supplied cmdline on standard
-# UKIs, so for ESP-mode UKIs we cannot write a snapshot entry that actually
-# boots into the snapshot — it would always boot the live root.
-#
-# Btrfs-mode UKI snapshots (UKI inside the snapshot's /boot/EFI/Linux/) are
-# always generated and unaffected by this setting.
+# UKIs are discovered and inspected but are not made snapshot-bootable by this
+# tool: the cmdline lives inside the signed .cmdline PE section and there is no
+# generally-reliable boot-loader-side override. Making snapshots bootable for
+# UKI hosts requires rewriting (and re-signing) the UKI per snapshot — tracked
+# as a planned standalone uki-btrfs-snapshots binary (see docs/WISHLIST.md).
 #
 # Spec: https://uapi-group.org/specifications/specs/boot_loader_specification/
 uki:
-  # ESP-mode UKI snapshot strategy:
-  #   "skip"    - Don't generate snapshot entries for ESP-mode UKIs (default — safest)
-  #   "warn"    - Generate the entry but log a clear warning that it boots live root
+  # Whether refind menu entries are generated for ESP-mode UKI sets:
+  #   "skip"    - Don't generate menu entries (default, recommended)
+  #   "warn"    - Generate the entry but log that it would boot live root, not the snapshot
   #   "disable" - Generate the entry with rEFInd's 'disabled' directive (visible but not bootable)
   snapshot_strategy: "skip"
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,7 +10,6 @@ Full documentation for `refind-btrfs-snapshots`. For installation and quick star
   - [Split Layout](#split-layout)
   - [BLS Layout](#bls-layout-boot-loader-specification-type-1)
   - [UKI Layout](#uki-layout-unified-kernel-image-bls-type-2)
-  - [UKI Snapshots: ESP-mode Caveat](#uki-snapshots-esp-mode-caveat)
 - [Commands](#commands)
   - [generate](#generate)
   - [list](#list)
@@ -104,27 +103,7 @@ A drop-in `.conf` file under `<esp>/loader/entries/*.conf` describes the entry. 
 
 A single PE/EFI binary at `<esp>/EFI/Linux/<name>.efi` containing the kernel, initramfs, cmdline, and OS-release metadata. The systemd-stub launches the embedded kernel with the embedded cmdline. Spec: <https://uapi-group.org/specifications/specs/boot_loader_specification/#type-2-efi-unified-kernel-images>.
 
-rEFInd treats UKIs as standard EFI loaders — it autodetects them from `<esp>/EFI/Linux/`. Generated UKI menu entries contain only a `loader` line. There is no `initrd` (it is embedded) and **no `options`** (the systemd-stub ignores boot-loader-supplied cmdline by default; passing `options` only takes effect if the UKI was built with cmdline addons).
-
-### UKI Snapshots: ESP-mode Caveat
-
-A UKI's embedded cmdline points at a specific root subvolume — there's no way for the boot loader to override it on a standard UKI. The implications differ depending on where the UKI lives:
-
-**Btrfs mode (UKI inside the snapshot's `/boot/EFI/Linux/`):**
-Each snapshot contains its own UKI with its own embedded cmdline pointing at that snapshot's subvolume. Booting the snapshot's UKI boots the snapshot. Fully supported.
-
-**ESP mode (UKI on the ESP, `<esp>/EFI/Linux/`):**
-The UKI's embedded cmdline points at the **live** root, not any snapshot. We cannot write a snapshot boot entry that actually enters the snapshot — the UKI will always boot live root regardless of what we put in `options`.
-
-Configure the response via `uki.snapshot_strategy`:
-
-| Strategy  | Behaviour                                                                                                                 |
-|-----------|---------------------------------------------------------------------------------------------------------------------------|
-| `skip` (default) | Do not generate snapshot entries for ESP-mode UKI sets. Safest — no misleading entries appear in the menu.          |
-| `warn`    | Generate the entry but log a clear warning that it will boot live root, not the snapshot.                                 |
-| `disable` | Generate the entry with rEFInd's `disabled` directive — visible in the menu but unbootable, signalling the limitation.    |
-
-Btrfs-mode UKI snapshots are unaffected by this setting and are always generated.
+**Discovery only — not snapshot-bootable.** We detect and inspect UKIs (they show up in `list bootsets`, `status`, and `kernel-spy`, and their embedded kernel version participates in staleness detection), but we do not produce snapshot boot entries for UKI boot sets. A snapshot-bootable cmdline is `rootflags=subvol=<snap>,subvolid=<id>`, and on a UKI that lives inside the signed `.cmdline` PE section — there's no generally-reliable boot-loader-side override, so making a snapshot bootable would require rewriting (and, under Secure Boot, re-signing) the UKI per snapshot. That's tracked as a planned standalone `uki-btrfs-snapshots` binary — see [`WISHLIST.md`](WISHLIST.md).
 
 ## Commands
 
@@ -328,7 +307,7 @@ esp:
 | **Logging** | `log_level` | `"info"` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | **Kernel** | `kernel.stale_snapshot_action` | `"delete"` | Action for stale snapshots: `delete`, `warn`, `disable`, `fallback` |
 | | `kernel.boot_image_patterns` | *(built-in)* | Custom boot image patterns (see config file) |
-| **UKI** | `uki.snapshot_strategy` | `"skip"` | Behaviour for ESP-mode UKI snapshots: `skip`, `warn`, `disable`. See [UKI Snapshots: ESP-mode Caveat](#uki-snapshots-esp-mode-caveat) |
+| **UKI** | `uki.snapshot_strategy` | `"skip"` | Whether refind menu entries are generated for ESP-mode UKI sets. `skip` (default) hides them, `warn`/`disable` emit entries that would boot the live root (not the snapshot) — see [UKI Layout](#uki-layout-unified-kernel-image-bls-type-2). |
 | **Advanced** | `advanced.naming.rwsnap_format` | `"2006-01-02_15-04-05"` | Timestamp format for writable snapshot filenames |
 | | `advanced.naming.menu_format` | `"2006-01-02T15:04:05Z"` | Timestamp format for menu entry titles |
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -4,7 +4,7 @@ Planned features and capabilities that aren't built yet. Items here are **not co
 
 ## Table of Contents
 
-- [`uki-btrfs-snapshots` binary (phase 3)](#uki-btrfs-snapshots-binary-phase-3)
+- [`uki-btrfs-snapshots` binary](#uki-btrfs-snapshots-binary)
   - [Intention](#intention)
   - [Outcome](#outcome)
   - [Approach](#approach)
@@ -13,7 +13,7 @@ Planned features and capabilities that aren't built yet. Items here are **not co
 
 ---
 
-## `uki-btrfs-snapshots` binary (phase 3)
+## `uki-btrfs-snapshots` binary
 
 A third sibling to `refind-btrfs-snapshots` and `bls-btrfs-snapshots` that makes btrfs snapshots bootable when the kernel is delivered as a UKI (Unified Kernel Image).
 
@@ -100,11 +100,11 @@ Practical concerns to surface in v1:
 
 So once we plumb config keys for these (`uki.signing.key_path`, `uki.signing.cert_path`, `uki.signing.signtool`, `uki.pcr.key_path`, etc.) and forward them as ukify flags, Secure Boot support is essentially free.
 
-**Phased rollout:**
+**Layered rollout** (do less initially, add more if anyone asks):
 
-- **v1 (initial release):** detect Secure Boot via `/sys/firmware/efi/efivars/SecureBoot-*`; if enabled and signing config is absent, refuse cleanly with a message pointing at the config knobs that will become available in v2. Don't silently ship unsigned UKIs the firmware will reject.
-- **v2:** wire the signing config through. The user provides their existing SB key/cert (the same ones their `kernel-install` setup uses), and the per-snapshot UKIs get signed identically.
-- **v3 (if anyone asks):** PCR signing for measured-boot setups. Note: changing the cmdline changes the PCR measurements, so TPM-sealed disks would fail to unlock for a snapshot-booted system unless the user's PCR policy explicitly enrolls the snapshot UKIs. This is fiddly and probably wants opt-in plus clear docs.
+- **Initial:** detect Secure Boot via `/sys/firmware/efi/efivars/SecureBoot-*`; if enabled and signing config is absent, refuse cleanly with a message pointing at the signing config keys. Don't silently ship unsigned UKIs the firmware will reject.
+- **With signing:** wire the signing config through. The user provides their existing SB key/cert (the same ones their `kernel-install` setup uses), and the per-snapshot UKIs get signed identically.
+- **With PCR:** PCR signing for measured-boot setups. Note: changing the cmdline changes the PCR measurements, so TPM-sealed disks would fail to unlock for a snapshot-booted system unless the user's PCR policy explicitly enrolls the snapshot UKIs. Fiddly; wants opt-in plus clear docs.
 
 ### Open questions
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -1,0 +1,115 @@
+# Wishlist
+
+Planned features and capabilities that aren't built yet. Items here are **not commitments** — they capture intent, surface design tradeoffs, and let us iterate on shape before code. Anything implementation-ready graduates out of this file and into an issue or PR.
+
+## Table of Contents
+
+- [`uki-btrfs-snapshots` binary (phase 3)](#uki-btrfs-snapshots-binary-phase-3)
+  - [Intention](#intention)
+  - [Outcome](#outcome)
+  - [Approach](#approach)
+  - [Secure Boot](#secure-boot)
+  - [Open questions](#open-questions)
+
+---
+
+## `uki-btrfs-snapshots` binary (phase 3)
+
+A third sibling to `refind-btrfs-snapshots` and `bls-btrfs-snapshots` that makes btrfs snapshots bootable when the kernel is delivered as a UKI (Unified Kernel Image).
+
+### Intention
+
+A UKI bundles kernel + initramfs + cmdline + os-release into a single signed PE binary that the firmware (or systemd-boot) can chainload directly. The cmdline lives **inside** the signed image as the `.cmdline` PE section, so neither the rEFInd nor the bls binary can make UKI-booting systems snapshot-bootable: they emit external bootloader config that proposes a cmdline, but the UKI ignores it. The cmdline that runs is whatever was baked into the UKI at build time.
+
+To make a snapshot bootable on a UKI-only system, we have to **produce a UKI per snapshot** with a per-snapshot cmdline embedded.
+
+### Outcome
+
+Per (snapshot × UKI source), emit one cloned UKI to `<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi` with:
+
+- `.linux` — same kernel as the source UKI (we don't rebuild kernels)
+- `.initrd` — same initramfs blob (microcode already concatenated if the source had it)
+- `.osrel` — same os-release
+- `.uname` — same kernel version string
+- `.cmdline` — **rewritten** with `rootflags=subvol=<snap-path>,subvolid=<snap-id>` per snapshot
+- `.sbat` — same (revocation metadata; doesn't depend on cmdline)
+
+Existing snapshot-fstab alignment (`internal/snapshotfs.UpdateFstabs`) applies unchanged.
+
+The binary follows the same shell as `bls-btrfs-snapshots`: cobra root + `generate`/`version` subcommands, opt-in `uki.write_entries` gate, dry-run / `--yes` / `--force` flags, the shared `cliconfig` + `internal/version` plumbing, the `internal/bootloader.Generator` interface, snapshot fstab alignment via the shared `snapshotfs` helper.
+
+### Approach
+
+Three editing strategies were tested empirically:
+
+| Strategy | Result | Verdict |
+|---|---|---|
+| `objcopy --update-section .cmdline=newfile` | Truncates: new content cut to old section size. PE sections have fixed allocated size and can't grow in-place. | Unusable — our rewritten cmdline is almost always longer than the source's |
+| `objcopy --remove-section .cmdline` + `--add-section` | Section size correct, but objcopy warns `section below image base`; PE layout integrity uncertain without a real boot test | Risky |
+| Extract sections via objcopy + rebuild via `ukify build` | Clean output, sha256-stable, valid UKI by construction (ukify handles section layout, alignment, signing path) | **Recommended** |
+
+Recommended flow per (snapshot × source UKI):
+
+```bash
+# 1. Pull the immutable sections out of the source.
+objcopy -O binary --only-section=.linux  source.efi tmp/linux
+objcopy -O binary --only-section=.initrd source.efi tmp/initrd
+objcopy -O binary --only-section=.osrel  source.efi tmp/osrel
+objcopy -O binary --only-section=.uname  source.efi tmp/uname
+objcopy -O binary --only-section=.sbat   source.efi tmp/sbat   # if present
+
+# 2. Compute the per-snapshot cmdline using the same rewriter the bls binary uses.
+NEW_CMDLINE="$(internal/bls/snapshot.go:rewriteCmdline equivalent for UKI)"
+
+# 3. Rebuild via ukify, passing through the extracted sections and the new cmdline.
+ukify build \
+  --linux=tmp/linux \
+  --initrd=tmp/initrd \
+  --os-release=@tmp/osrel \
+  --uname="$(tr -d '\0' < tmp/uname)" \
+  --sbat=@tmp/sbat \
+  --cmdline="$NEW_CMDLINE" \
+  --output=<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi
+```
+
+`ukify` ships with systemd (≥ v253). Detect at runtime; refuse cleanly with a pointer to the distro package (`systemd-ukify` on Arch, etc.) if missing.
+
+Practical concerns to surface in v1:
+
+| Concern | Mitigation |
+|---|---|
+| **Disk usage** — each UKI clone is a full ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `snapshot.selection_count` becomes load-bearing. Detect ESP free space before applying and refuse if insufficient. Surface the per-snapshot size in dry-run output. |
+| **Runtime dependency on `ukify`** | Detect at startup, error early with an actionable message. |
+| **Build cost** — ~2–3 s per UKI (compression dominates) | Progress logs per snapshot. Total for 25 snapshots: under a minute. Acceptable for a hourly-triggered service. |
+| **Microcode** | Source UKIs already concatenate microcode into the single `.initrd` section. Pass the extracted blob back to ukify verbatim — no microcode-specific handling needed. |
+
+### Secure Boot
+
+**ukify natively handles Secure Boot signing** — we don't reimplement anything. Relevant flags:
+
+| ukify flag | Purpose |
+|---|---|
+| `--secureboot-private-key=PATH` | Private key for the PE signature |
+| `--secureboot-certificate=PATH` | Cert for the PE signature |
+| `--signtool={sbsign,pesign,systemd-sbsign}` | Choose the signing backend |
+| `--sign-kernel` / `--no-sign-kernel` | Sign the embedded kernel separately (some SB shim configurations want this) |
+| `--pcr-private-key=PATH` | Private key for PCR signing (TPM2 measured boot) |
+| `--pcr-public-key=PATH` / `--pcr-certificate=PATH` | Verification material for PCR sigs |
+| `--measure` / `--no-measure` | Whether to compute PCR measurements during build |
+| `--sign-profile ID` | Which PCR profile to sign |
+
+So once we plumb config keys for these (`uki.signing.key_path`, `uki.signing.cert_path`, `uki.signing.signtool`, `uki.pcr.key_path`, etc.) and forward them as ukify flags, Secure Boot support is essentially free.
+
+**Phased rollout:**
+
+- **v1 (initial release):** detect Secure Boot via `/sys/firmware/efi/efivars/SecureBoot-*`; if enabled and signing config is absent, refuse cleanly with a message pointing at the config knobs that will become available in v2. Don't silently ship unsigned UKIs the firmware will reject.
+- **v2:** wire the signing config through. The user provides their existing SB key/cert (the same ones their `kernel-install` setup uses), and the per-snapshot UKIs get signed identically.
+- **v3 (if anyone asks):** PCR signing for measured-boot setups. Note: changing the cmdline changes the PCR measurements, so TPM-sealed disks would fail to unlock for a snapshot-booted system unless the user's PCR policy explicitly enrolls the snapshot UKIs. This is fiddly and probably wants opt-in plus clear docs.
+
+### Open questions
+
+- **Cleanup model:** how aggressively do we remove orphan UKI clones? The bls binary cleans up by prefix-match. Same pattern here, but with ~70 MB per file the consequences of leaving orphans around are different from the bls binary's ~1 KB `.conf` files.
+- **Naming:** does `bls-btrfs-snapshots-` style prefix apply, or do we use `uki-btrfs-snapshots-` to keep them clearly separable from any user-managed UKIs?
+- **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (e.g., shim-aware variants). Detect the source UKI's stub and reuse it, or always use the system stub? Probably reuse — preserves whatever security profile the original was built with.
+- **Cross-arch:** the systemd stub is per-arch. For aarch64 boxes we'd need `linuxaa64.efi.stub`. The matrix is already arch-aware (we build the binary for amd64/arm64); the runtime just picks the stub matching the running architecture.
+- **Coexistence with `kernel-install`:** distro `kernel-install` plugins regenerate the primary UKI on every kernel rebuild. Our managed clones (with the managed prefix) won't conflict with the primary, but we need to re-trigger after a kernel rebuild. The systemd `.path` unit watching `/.snapshots/` doesn't catch kernel rebuilds — we'd want a second trigger watching `/boot/EFI/Linux/` for source UKI changes. Worth thinking about before phase 3 ships.


### PR DESCRIPTION
## Summary

Docs-only PR with two parts:

### 1. Add `docs/WISHLIST.md`

Captures planned-but-not-built work at design level. First entry: the `uki-btrfs-snapshots` binary. Covers intention, outcome, three editing strategies tested empirically (only extract-and-rebuild-via-ukify works cleanly), how Secure Boot integration falls out from ukify's native signing flags, and open questions (cleanup, naming, stub override, cross-arch, kernel-install coexistence).

Explicit that items here are not commitments — they graduate out to issues or PRs when implementation-ready.

### 2. Correct existing UKI docs

README/USAGE previously implied btrfs-mode UKI snapshots were "fully supported" and that we generate snapshot-bootable UKI menu entries. Both claims are misleading:

- A UKI's cmdline lives in the signed `.cmdline` PE section, not externally
- There's no general boot-loader-side override
- A snapshot's UKI is a verbatim copy of the live UKI at snapshot time, so its embedded cmdline still references the live root — booting it boots the live root, regardless of mode

Replaced the overstated wording with an honest discovery-only summary across `README.md`, `docs/USAGE.md`, and `configs/refind-btrfs-snapshots.yaml`. All UKI mentions now point at `WISHLIST.md` for the planned solution.

## Out of scope (followup)

The planner code still emits ESP-mode UKI plans per strategy and btrfs-mode UKI plans unconditionally. None actually produce snapshot-bootable entries. Worth cleaning up separately — either stop emitting them, or require explicit opt-in. Captured in the commit message as a future-work note, not addressed in this PR.

## Test plan

Docs-only — no code paths touched. Just ensures the markdown renders correctly on GitHub.