### PR TITLE
docs: rework WISHLIST uki entry — cloned vs multi-profile, bootloader matrix

### DIFF
--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -33,8 +33,8 @@ The community has two working answers; this binary supports both, **independentl
 
 | Mode | Per-snapshot disk cost | Works under SB | Boot paths that can select per snapshot |
 |---|---|---|---|
-| **1. Cloned UKIs** (one .efi per snapshot) | ~70 MB each (kernel + initrd duplicated) | Yes (re-sign each clone) | Anything that can launch a `.efi` from the ESP — direct firmware boot, refind, systemd-boot, GRUB chainload, limine. **Universal.** |
-| **2. Multi-profile UKI** (single .efi with N `.profile` sections) | ~few KB each (only `.cmdline` per profile; kernel/initrd shared) | Yes (single signed image) | Only paths that pass an `@N` profile prefix to the sd-stub. **Currently: systemd-boot with sd-stub; manually-crafted refind entries.** |
+| **1. Cloned UKIs** (one .efi per snapshot) | Full UKI size each (kernel + initrd duplicated) | Yes (re-sign each clone) | Anything that can launch a `.efi` from the ESP — direct firmware boot, refind, systemd-boot, GRUB chainload, limine. **Universal.** |
+| **2. Multi-profile UKI** (single .efi with N `.profile` sections) | Profile-metadata + cmdline only; kernel/initrd shared across all profiles in one UKI | Yes (single signed image) | Only paths that pass an `@N` profile prefix to the sd-stub. **Currently: systemd-boot with sd-stub; manually-crafted refind entries.** |
 
 The two are not mutually exclusive. Plausible combinations:
 
@@ -48,15 +48,15 @@ The two are not mutually exclusive. Plausible combinations:
 uki:
   # Which mode(s) to apply. Both are independent; both are enabled by default
   # so installing the binary gives you the full coverage matrix: multi-profile
-  # for systemd-boot menu integration with sd-stub, plus 10 universal-fallback
+  # for systemd-boot menu integration with sd-stub, plus universal-fallback
   # clones for direct-firmware boot or systemd-boot menu recovery.
   modes: [clone, multi-profile]
 
   clone:
-    # N most recent snapshots overall get cloned. Each clone is a full ~70 MB
-    # .efi file (kernel + initrd duplicated; only .cmdline differs from the
-    # source UKI). Cloning is per (snapshot × the kernel matching that snapshot's
-    # modules), NOT per snapshot × every kernel.
+    # N most recent snapshots overall get cloned. Each clone is a full .efi
+    # the same size as the source UKI (kernel + initrd duplicated; only
+    # .cmdline differs). Cloning is per (snapshot × the kernel matching that
+    # snapshot's modules), NOT per snapshot × every kernel.
     # 0 = unlimited (inherits snapshot.selection_count — caller beware).
     recent: 4
 
@@ -80,9 +80,10 @@ uki:
 
   multi_profile:
     # Cap on profiles joined to the base UKI. One base UKI per kernel; each
-    # carries one .profile section per eligible snapshot. Profiles are cheap
-    # (~few KB each) so this defaults unlimited — the practical cap is
-    # snapshot.selection_count.
+    # carries one .profile section per eligible snapshot. A profile only adds
+    # its own .cmdline (plus a small metadata block) — the kernel/initrd are
+    # shared across all profiles in the UKI, so per-profile disk cost is
+    # negligible relative to the UKI itself.
     # 0 = inherit snapshot.selection_count.
     recent: 0
 
@@ -92,15 +93,15 @@ uki:
     cert_path: ""
 ```
 
-**Default footprint** for a single-kernel system with 25 selected snapshots:
-- Live UKI (kernel-install owned): ~70 MB — **untouched by us**
-- Managed snapshot UKI (us): ~70 MB (clone of live UKI + 25 profile sections, ~50 KB metadata overhead)
-- Clones: **4 × ~70 MB ≈ 280 MB**
-- **Total ≈ 350 MB additional disk, 6 `.efi` files on the ESP** (1 live UKI + 1 managed snapshot UKI + 4 cloned UKIs).
+**Default footprint** for a single-kernel system with `clone.recent: 4`:
+- Live UKI (kernel-install owned, untouched by us): **1 UKI on disk**
+- Managed snapshot UKI (us, contains all snapshot profiles): **1 UKI on disk**
+- Clones: **4 UKIs on disk**
+- **Total: 6 `.efi` files** (1 live + 1 managed snapshot + 4 clones).
 
-For two-kernel systems: ~420 MB additional (one managed snapshot UKI per kernel + 4 shared clones). 8 `.efi` files total.
+For a two-kernel system: one managed snapshot UKI per kernel + 4 shared clones = **8 `.efi` files** total.
 
-This comfortably fits a 512 MB ESP with room for other content. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow.
+Each UKI is full-size (kernel + initrd embedded). Actual byte cost varies entirely with the distro's kernel and initramfs size and compression settings — measure on the target system before tuning the caps. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow.
 
 **Reconciliation, not append.** Every run computes the desired set from scratch — covering both clones AND managed snapshot UKIs — scans the ESP under the managed prefix, and reconciles:
 
@@ -129,7 +130,7 @@ This comfortably fits a 512 MB ESP with room for other content. The pre-flight c
 | Live kernel A uninstalled AND no remaining snapshot has compatible modules | Remove — no data depends on it anymore |
 | Live kernel A installed + brand-new system, no snapshots yet | Keep — kernel is installed |
 
-**Bound on proliferation.** Each managed UKI only contains profiles for snapshots whose modules match its embedded kernel — a snapshot doesn't appear in two managed UKIs. So total profile count across all managed UKIs ≤ total eligible snapshot count. The disk cost scales with *distinct kernel versions* seen across the snapshot window, not with snapshot count. A user keeping 30 days of daily snapshots through 1-2 kernel upgrades has 1-2 managed UKIs (~70-140 MB), not one per snapshot.
+**Bound on proliferation.** Each managed UKI only contains profiles for snapshots whose modules match its embedded kernel — a snapshot doesn't appear in two managed UKIs. So total profile count across all managed UKIs ≤ total eligible snapshot count. The disk cost scales with the *number of distinct kernel versions* spanned by the snapshot window (each kernel needs its own managed UKI to embed that kernel's binary), not with snapshot count. A user keeping 30 days of daily snapshots through 1-2 kernel upgrades typically ends up with 1-2 managed UKIs.
 
 **The historical kernel preservation property is a side-effect.** When kernel A is uninstalled from the live system, our managed UKI for A becomes the **only** remaining copy of that kernel binary on disk — it's preserved inside the `.linux` PE section. This makes the managed UKI the authoritative recovery path for any snapshot that needs that kernel, until the last such snapshot is pruned. That's the right behaviour: the artefact's lifetime is bound to the data that depends on it.
 
@@ -151,12 +152,12 @@ If the default is **insufficient** — specifically, you want direct-firmware-bo
 
 | Day | `per_kernel_minimum: 0` (default) | `per_kernel_minimum: 1` |
 |---|---|---|
-| 8 (after A→B) | 4 B-clones (~280 MB) | 4 B + 1 A = 5 (~350 MB) |
-| 16 (after B→C) | 4 C-clones | 4 C + 1 B + 1 A = 6 (~420 MB) |
-| 24 (after C→D) | 4 D-clones | 4 D + 1 C + 1 B + 1 A = 7 (~490 MB) |
-| 32 (A snaps pruned) | 4 D-clones | 4 D + 1 C + 1 B = 6 (~420 MB) — A naturally retires |
+| 8 (after A→B) | 4 B-clones | 4 B + 1 A = 5 clones |
+| 16 (after B→C) | 4 C-clones | 4 C + 1 B + 1 A = 6 clones |
+| 24 (after C→D) | 4 D-clones | 4 D + 1 C + 1 B + 1 A = 7 clones |
+| 32 (A snaps pruned) | 4 D-clones | 4 D + 1 C + 1 B = 6 clones — A naturally retires |
 
-`per_kernel_minimum: 1` adds ~70 MB per still-bootable historical kernel; they retire as the underlying snapshots age out of btrfs retention.
+`per_kernel_minimum: 1` adds one full UKI's worth of disk per still-bootable historical kernel; they retire as the underlying snapshots age out of btrfs retention.
 
 The implementation note: mode 2's managed UKI is a separate file from the kernel-install-owned live UKI. We never modify the live UKI in place; this avoids the kernel-install clobber race entirely. On kernel upgrades, our `.path` unit (watching the live UKI's mtime in addition to `/.snapshots/`) regenerates the managed snapshot UKI from the new live UKI. No "repair" step is needed because we always rebuild from scratch.
 
@@ -230,7 +231,7 @@ ukify build \
 
 | Concern | Mitigation |
 |---|---|
-| Each clone is ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `uki.clone.recent` caps the count separately from `snapshot.selection_count`; default is 4 (≈280 MB) — fits a 512 MB ESP with headroom. Pre-flight check: compute the required size and refuse if the ESP doesn't have headroom. |
+| Each clone is full-UKI-sized (kernel + initrd embedded). Without a cap, N snapshots × UKI size easily eats an ESP. | `uki.clone.recent` caps the count separately from `snapshot.selection_count`; default is 4. The pre-flight check computes the required size at runtime against the actual UKI size on disk and refuses if the ESP doesn't have headroom. |
 | Runtime dep on `ukify` (systemd ≥ v253) | Detect at startup; error early with package hint. |
 | Build cost ~2-3 s per UKI | Show per-snapshot progress logs. |
 | Choosing which N to clone when `recent` < total snapshots | Newest-first by `SnapshotTime`. Same ordering the bls binary uses. |
@@ -289,12 +290,12 @@ ukify build \
 
 | Concern | Mitigation |
 |---|---|
-| One extra UKI-sized file per kernel (~70 MB each) on the ESP | This is the cost of clean ownership separation from kernel-install. Accept and document. |
+| One extra UKI-sized file per kernel on the ESP | This is the cost of clean ownership separation from kernel-install. Accept and document. |
 | Snapshot UKI must stay in sync with live UKI's kernel/initrd after kernel updates | `.path` unit also watches mtime on `<esp>/EFI/Linux/<kernel>.efi`; when it changes (kernel-install ran), regenerate the snapshot UKI. No "repair" needed — just regenerate fresh. |
 | Only useful if the boot path actually passes `@N` (for profiles > 0) | Profile `@0 = newest snapshot` ensures direct firmware boot does something useful even without `@N` support. Log a notice if firmware-direct-boot is the active path, recommending also enabling `clone` for older snapshots. |
 | Requires ukify ≥ 256 for `--join-profile` | Detect at startup. |
 | Per-snapshot BLS entries with `options @<ID>` still useful for systemd-boot's menu | Optional; write them alongside if the user wants explicit menu entries beyond what systemd-boot may auto-synthesize. |
-| Number of joined profiles bounded by `uki.multi_profile.recent` | Default unbounded — profiles are cheap (~few KB each). |
+| Number of joined profiles bounded by `uki.multi_profile.recent` | Default unbounded — profile-metadata + per-profile cmdline are tiny relative to the shared kernel/initrd. |
 
 ### Secure Boot
 
@@ -317,10 +318,10 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 
 ### Open questions
 
-- **Both modes enabled by default**, gated only by package install (≈280 MB ESP footprint for the default single-kernel + 25-snapshot + `clone.recent: 4` setup). Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here. Users wanting to tune down: set `modes: [clone]`, `modes: [multi-profile]`, `clone.recent: 2`, or `modes: []` to opt out entirely.
+- **Both modes enabled by default**, gated only by package install. Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here. The mandatory pre-flight ESP free-space check (which sizes from the actual UKI on disk, not from any baked-in assumption) is the safety net against tight ESPs. Users wanting to tune down: set `modes: [clone]`, `modes: [multi-profile]`, `clone.recent: 2`, or `modes: []` to opt out entirely.
 - **Pre-flight space check operates against additions only**, after pruning aged-out clones (`desired − on_disk` and `on_disk − desired` computed each run; deletions applied first). Refusal happens only if even the post-pruning projection won't fit. This prevents the rollback safety net from silently degrading over time when the ESP is tight.
 - **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
-- **`uki.clone.recent` default of 4:** chosen for ~280 MB headroom on a 512 MB ESP (the smaller-end size that still occurs in the wild). Yields 5 `.efi` files total on a single-kernel system (1 live multi-profile UKI + 4 clones). Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to before raising the cap.
+- **`uki.clone.recent` default of 4:** chosen conservatively because the actual byte cost depends on the host's UKI size, which we can't predict. Four clones is a reasonable compromise between "useful recovery set" and "doesn't blindly fill the ESP on hosts with large UKIs". Dry-run output should show the real numbers (actual UKI size × proposed clone count) so users see what they'd commit to before raising the cap.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.
 - **kernel-install coexistence:** mode 2's separate managed snapshot UKI sidesteps the clobber problem entirely — kernel-install owns the live UKI; we own the snapshot UKI; the two never overlap. On kernel updates, `kernel-install` regenerates the live UKI as normal, and our `.path` unit (watching live-UKI mtime in addition to `/.snapshots/`) regenerates the snapshot UKI from the new kernel/initrd. Mode 1's clones also need refresh after kernel upgrades — same `.path` trigger handles both.
 - **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (shim-aware variants). Detect the source UKI's stub and reuse it.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -7,6 +7,8 @@ Planned features and capabilities that aren't built yet. Items here are **not co
 - [`uki-btrfs-snapshots` binary](#uki-btrfs-snapshots-binary)
   - [The fundamental problem](#the-fundamental-problem)
   - [Two implementation modes](#two-implementation-modes)
+    - [Config shape](#config-shape)
+    - [Profile display names](#profile-display-names)
   - [Bootloader / firmware support matrix](#bootloader--firmware-support-matrix)
   - [Mode 1: Cloned UKIs per snapshot (default)](#mode-1-cloned-ukis-per-snapshot-default)
   - [Mode 2: Multi-profile UKI (opt-in)](#mode-2-multi-profile-uki-opt-in)
@@ -27,14 +29,62 @@ A snapshot-bootable cmdline is `rootflags=subvol=<snap-path>,subvolid=<snap-id>`
 
 ### Two implementation modes
 
-The community has two working answers; this binary should support both as alternatives selectable via config. They differ in storage cost and in which boot paths can consume them:
+The community has two working answers; this binary supports both, **independently selectable as a list** so users can run either or both at once. They differ in storage cost and in which boot paths can consume them:
 
 | Mode | Per-snapshot disk cost | Works under SB | Boot paths that can select per snapshot |
 |---|---|---|---|
 | **1. Cloned UKIs** (one .efi per snapshot) | ~70 MB each (kernel + initrd duplicated) | Yes (re-sign each clone) | Anything that can launch a `.efi` from the ESP — direct firmware boot, refind, systemd-boot, GRUB chainload, limine. **Universal.** |
 | **2. Multi-profile UKI** (single .efi with N `.profile` sections) | ~few KB each (only `.cmdline` per profile; kernel/initrd shared) | Yes (single signed image) | Only paths that pass an `@N` profile prefix to the sd-stub. **Currently: systemd-boot with sd-stub; manually-crafted refind entries.** |
 
-Mode 1 is the **default** because it works for every boot path that exists today, including direct-firmware-boot — UEFI firmware has no concept of profiles and cannot pass an `@N` selector, so a multi-profile UKI registered as a `BootXXXX` entry will always boot profile @0. Mode 2 is the more *architecturally* attractive answer and what we'd recommend if/when bootloader support catches up.
+The two are not mutually exclusive. Plausible combinations:
+
+- **`clone` only** — universal compatibility, accept disk cost. Most conservative default.
+- **`multi-profile` only** — systemd-boot users on tight ESPs; cheapest per-snapshot.
+- **Both** — multi-profile for the systemd-boot menu (cheap, many profiles), plus a small number of clones as a universal recovery fallback (e.g., last 3 known-good).
+
+#### Config shape
+
+```yaml
+uki:
+  # Which mode(s) to apply. Both are independent; you can enable either or both.
+  modes: [clone]                      # default; alternatives: [multi-profile], [clone, multi-profile]
+
+  clone:
+    # Cap on how many snapshots get cloned. Cloning is expensive (~70 MB each)
+    # so this defaults conservatively; ESPs are typically 512 MB - 1 GB. The
+    # binary refuses to apply if the resulting set wouldn't fit alongside what's
+    # already on the ESP.
+    # 0 = inherit snapshot.selection_count (caller beware).
+    recent: 10
+
+  multi_profile:
+    # Cap on how many profiles join the base UKI. Profiles cost a few KB each
+    # so this can run unlimited safely in normal cases.
+    # 0 = inherit snapshot.selection_count.
+    recent: 0
+
+  # Signing: see Secure Boot section.
+  signing:
+    key_path: ""
+    cert_path: ""
+```
+
+#### Profile display names
+
+Each `.profile` section in a multi-profile UKI carries metadata fields from the [UAPI spec](https://uapi-group.org/specifications/specs/unified_kernel_image/):
+
+| Field | Purpose |
+|---|---|
+| `ID=` | Brief 7-bit ASCII identifier — used as the value passed via `@<ID>` (or `@<index>`) to sd-stub at boot |
+| `TITLE=` | Human-readable text for boot menu display |
+
+So each snapshot's profile can carry its own title — we'd set `TITLE=Linux-cachyos (2026-05-27T16:00:00Z)` (same format as the bls binary's entry titles, honouring `advanced.naming.menu_format` + `display.local_time`). Where that title actually surfaces depends on the consumer:
+
+- **systemd-boot** with native profile-menu synthesis: TITLE shows as a top-level menu entry. (Per the UAPI spec this is "may", not "does" — depends on systemd-boot version.)
+- **systemd-boot** with hand-written BLS `.conf` per profile: the `.conf`'s own `title` line wins; the profile's TITLE is just metadata stored in the UKI.
+- **refind** with manual `refind.conf` per profile: same — refind's menu name comes from its own config.
+
+For mode 1 (clones), each clone is just a normal UKI; its "title" in a boot menu is whatever the surrounding BLS `.conf` or `refind.conf` entry declares.
 
 ### Bootloader / firmware support matrix
 
@@ -89,9 +139,10 @@ ukify build \
 
 | Concern | Mitigation |
 |---|---|
-| Each clone is ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `snapshot.selection_count` becomes load-bearing. Detect ESP free space before applying. |
+| Each clone is ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `uki.clone.recent` caps the count separately from `snapshot.selection_count`; default is 10 (≈700 MB). Pre-flight check: compute the required size and refuse if the ESP doesn't have headroom. |
 | Runtime dep on `ukify` (systemd ≥ v253) | Detect at startup; error early with package hint. |
 | Build cost ~2-3 s per UKI | Show per-snapshot progress logs. |
+| Choosing which N to clone when `recent` < total snapshots | Newest-first by `SnapshotTime`. Same ordering the bls binary uses. |
 
 ### Mode 2: Multi-profile UKI (opt-in)
 
@@ -131,10 +182,11 @@ ukify build \
 
 | Concern | Mitigation |
 |---|---|
-| Only useful if the boot path actually passes `@N` | Detect: if firmware-direct-boot is the active path, refuse cleanly with a message saying "your boot path doesn't support multi-profile UKIs; switch to mode 1 (clone)". |
+| Only useful if the boot path actually passes `@N` | Detect: if firmware-direct-boot is the active path, log a clear warning and recommend enabling `clone` alongside (modes is a list — they're additive). |
 | Replaces the original UKI in place — `kernel-install` may overwrite | Hook into `kernel-install` (provide a `90-uki-btrfs-snapshots.install` script) to re-join profiles after kernel upgrades. |
 | Requires ukify ≥ 256 for `--join-profile` | Detect at startup. |
 | Per-snapshot BLS entries with `options @N ` are still needed for systemd-boot's menu | Write them alongside, same as the bls binary's existing flow. |
+| Number of joined profiles bounded by `uki.multi_profile.recent` | Default unbounded — profiles are cheap (~KB), no realistic limit. Caps are only useful if a user wants the menu trimmed. |
 
 ### Secure Boot
 
@@ -157,7 +209,8 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 
 ### Open questions
 
-- **Mode selection:** static config (`uki.mode: clone | multi-profile`) or auto-detect from the boot path? Auto-detect is tempting but reading the active `BootXXXX` and inferring "this UKI was launched directly by firmware" is fragile. Prefer explicit config with a sensible default (`clone`).
+- **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
+- **`uki.clone.recent` default of 10:** chosen for ~700 MB headroom on a typical 1 GB ESP. Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.
 - **kernel-install coexistence:** distro `kernel-install` plugins regenerate the primary UKI on kernel upgrades, which clobbers any joined profiles. We need a kernel-install hook in mode 2 (and to detect+re-emit clones in mode 1). The systemd `.path` unit watching `/.snapshots/` doesn't fire on kernel rebuilds; need a second trigger watching `/boot/EFI/Linux/`.
 - **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (shim-aware variants). Detect the source UKI's stub and reuse it.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -53,15 +53,30 @@ uki:
   modes: [clone, multi-profile]
 
   clone:
-    # Cap on how many snapshots get cloned. Each clone is a full ~70 MB .efi
-    # file (kernel + initrd duplicated; only .cmdline differs from the source
-    # UKI). Pick whichever boot-set's kernel each cloned snapshot was taken
-    # under — cloning is per (snapshot × associated kernel), NOT per snapshot
-    # × every kernel. The binary runs a mandatory pre-flight ESP free-space
-    # check and refuses to apply if the projected set wouldn't fit alongside
-    # what's already on the ESP.
+    # N most recent snapshots overall get cloned. Each clone is a full ~70 MB
+    # .efi file (kernel + initrd duplicated; only .cmdline differs from the
+    # source UKI). Cloning is per (snapshot × the kernel matching that snapshot's
+    # modules), NOT per snapshot × every kernel.
     # 0 = unlimited (inherits snapshot.selection_count — caller beware).
     recent: 4
+
+    # Minimum clones per kernel that still has retained snapshots, in addition
+    # to whatever `recent` covers. Without this, immediately after a kernel
+    # upgrade the "newest 4" all become current-kernel and you lose any direct-
+    # bootable recovery clone for older kernels (the managed UKI's profile @0
+    # still covers them, but only for systemd-boot / sd-stub-aware paths).
+    # Setting `per_kernel_minimum: 1` guarantees at least one direct-bootable
+    # recovery target per historical kernel — they retire naturally as the
+    # underlying snapshots age out.
+    # 0 = no per-kernel guarantee (current behaviour); recommend 1 for systems
+    # where direct firmware boot is the recovery path.
+    per_kernel_minimum: 0
+
+    # Optional hard cap on total clones across all kernels. Catches runaway
+    # interaction between `recent` × many distinct kernels × `per_kernel_minimum`.
+    # Excess is pruned newest-first within each kernel until the cap is met.
+    # 0 = unbounded.
+    maximum_total: 0
 
   multi_profile:
     # Cap on profiles joined to the base UKI. One base UKI per kernel; each
@@ -130,7 +145,18 @@ This means the clone set **always tracks the newest N**, even on a tight ESP —
 
 The refusal reason and orphan state are recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so they survive until the next successful run.
 
-If the default is still too aggressive: setting `modes: [multi-profile]` alone drops to ~0 MB additional (in-place only); setting `clone.recent: 2` halves the clone cost; setting `modes: []` opts out entirely.
+If the default is still too aggressive: setting `modes: [multi-profile]` drops the clone cost entirely; setting `clone.recent: 2` halves it; setting `modes: []` opts out.
+
+If the default is **insufficient** — specifically, you want direct-firmware-boot access to recovery targets across kernel upgrades, not just to the most recent 4 snapshots — set `clone.per_kernel_minimum: 1`. Worked example for the 3-upgrades-in-24-days scenario (hourly + daily snapshots, 24+24 retention):
+
+| Day | `per_kernel_minimum: 0` (default) | `per_kernel_minimum: 1` |
+|---|---|---|
+| 8 (after A→B) | 4 B-clones (~280 MB) | 4 B + 1 A = 5 (~350 MB) |
+| 16 (after B→C) | 4 C-clones | 4 C + 1 B + 1 A = 6 (~420 MB) |
+| 24 (after C→D) | 4 D-clones | 4 D + 1 C + 1 B + 1 A = 7 (~490 MB) |
+| 32 (A snaps pruned) | 4 D-clones | 4 D + 1 C + 1 B = 6 (~420 MB) — A naturally retires |
+
+`per_kernel_minimum: 1` adds ~70 MB per still-bootable historical kernel; they retire as the underlying snapshots age out of btrfs retention.
 
 The implementation note: mode 2's managed UKI is a separate file from the kernel-install-owned live UKI. We never modify the live UKI in place; this avoids the kernel-install clobber race entirely. On kernel upgrades, our `.path` unit (watching the live UKI's mtime in addition to `/.snapshots/`) regenerates the managed snapshot UKI from the new live UKI. No "repair" step is needed because we always rebuild from scratch.
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -5,9 +5,11 @@ Planned features and capabilities that aren't built yet. Items here are **not co
 ## Table of Contents
 
 - [`uki-btrfs-snapshots` binary](#uki-btrfs-snapshots-binary)
-  - [Intention](#intention)
-  - [Outcome](#outcome)
-  - [Approach](#approach)
+  - [The fundamental problem](#the-fundamental-problem)
+  - [Two implementation modes](#two-implementation-modes)
+  - [Bootloader / firmware support matrix](#bootloader--firmware-support-matrix)
+  - [Mode 1: Cloned UKIs per snapshot (default)](#mode-1-cloned-ukis-per-snapshot-default)
+  - [Mode 2: Multi-profile UKI (opt-in)](#mode-2-multi-profile-uki-opt-in)
   - [Secure Boot](#secure-boot)
   - [Open questions](#open-questions)
 
@@ -17,99 +19,151 @@ Planned features and capabilities that aren't built yet. Items here are **not co
 
 A third sibling to `refind-btrfs-snapshots` and `bls-btrfs-snapshots` that makes btrfs snapshots bootable when the kernel is delivered as a UKI (Unified Kernel Image).
 
-### Intention
+### The fundamental problem
 
-A UKI bundles kernel + initramfs + cmdline + os-release into a single signed PE binary that the firmware (or systemd-boot) can chainload directly. The cmdline lives **inside** the signed image as the `.cmdline` PE section, so neither the rEFInd nor the bls binary can make UKI-booting systems snapshot-bootable: they emit external bootloader config that proposes a cmdline, but the UKI ignores it. The cmdline that runs is whatever was baked into the UKI at build time.
+A UKI bundles kernel + initramfs + cmdline + os-release into a single PE binary that the firmware (or a boot loader) chainloads. The cmdline lives **inside** the image as the `.cmdline` PE section. Under Secure Boot the embedded cmdline is authoritative — the boot loader cannot override it; without Secure Boot the systemd-stub *may* accept boot-loader-supplied cmdline, but relying on that defeats the security model anyway.
 
-To make a snapshot bootable on a UKI-only system, we have to **produce a UKI per snapshot** with a per-snapshot cmdline embedded.
+A snapshot-bootable cmdline is `rootflags=subvol=<snap-path>,subvolid=<snap-id>` — it must change per snapshot. So neither the rEFInd nor the bls binary makes UKI hosts snapshot-bootable: external `options=` strings are ignored. We need to put the snapshot-targeted cmdline **inside** a UKI that the boot path will actually execute.
 
-### Outcome
+### Two implementation modes
 
-Per (snapshot × UKI source), emit one cloned UKI to `<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi` with:
+The community has two working answers; this binary should support both as alternatives selectable via config. They differ in storage cost and in which boot paths can consume them:
 
-- `.linux` — same kernel as the source UKI (we don't rebuild kernels)
-- `.initrd` — same initramfs blob (microcode already concatenated if the source had it)
-- `.osrel` — same os-release
-- `.uname` — same kernel version string
-- `.cmdline` — **rewritten** with `rootflags=subvol=<snap-path>,subvolid=<snap-id>` per snapshot
-- `.sbat` — same (revocation metadata; doesn't depend on cmdline)
+| Mode | Per-snapshot disk cost | Works under SB | Boot paths that can select per snapshot |
+|---|---|---|---|
+| **1. Cloned UKIs** (one .efi per snapshot) | ~70 MB each (kernel + initrd duplicated) | Yes (re-sign each clone) | Anything that can launch a `.efi` from the ESP — direct firmware boot, refind, systemd-boot, GRUB chainload, limine. **Universal.** |
+| **2. Multi-profile UKI** (single .efi with N `.profile` sections) | ~few KB each (only `.cmdline` per profile; kernel/initrd shared) | Yes (single signed image) | Only paths that pass an `@N` profile prefix to the sd-stub. **Currently: systemd-boot with sd-stub; manually-crafted refind entries.** |
 
-Existing snapshot-fstab alignment (`internal/snapshotfs.UpdateFstabs`) applies unchanged.
+Mode 1 is the **default** because it works for every boot path that exists today, including direct-firmware-boot — UEFI firmware has no concept of profiles and cannot pass an `@N` selector, so a multi-profile UKI registered as a `BootXXXX` entry will always boot profile @0. Mode 2 is the more *architecturally* attractive answer and what we'd recommend if/when bootloader support catches up.
 
-The binary follows the same shell as `bls-btrfs-snapshots`: cobra root + `generate`/`version` subcommands, opt-in `uki.write_entries` gate, dry-run / `--yes` / `--force` flags, the shared `cliconfig` + `internal/version` plumbing, the `internal/bootloader.Generator` interface, snapshot fstab alignment via the shared `snapshotfs` helper.
+### Bootloader / firmware support matrix
 
-### Approach
+What "selects a per-snapshot variant" looks like for each consumer, today:
 
-Three editing strategies were tested empirically:
-
-| Strategy | Result | Verdict |
+| Consumer | Cloned UKI | Multi-profile UKI |
 |---|---|---|
-| `objcopy --update-section .cmdline=newfile` | Truncates: new content cut to old section size. PE sections have fixed allocated size and can't grow in-place. | Unusable — our rewritten cmdline is almost always longer than the source's |
-| `objcopy --remove-section .cmdline` + `--add-section` | Section size correct, but objcopy warns `section below image base`; PE layout integrity uncertain without a real boot test | Risky |
-| Extract sections via objcopy + rebuild via `ukify build` | Clean output, sha256-stable, valid UKI by construction (ukify handles section layout, alignment, signing path) | **Recommended** |
+| **UEFI firmware direct boot** (`efibootmgr` entry per UKI) | ✅ One `BootXXXX` per snapshot — clunky but works | ❌ Firmware has no `@N` selector; always boots profile @0 |
+| **systemd-boot** (sd-stub ≥ 256) | ✅ One BLS `.conf` per UKI, auto-discovered from `<esp>/EFI/Linux/` | 🟡 [Native menu synthesis from profiles is documented as "may", not "does"](https://uapi-group.org/specifications/specs/unified_kernel_image/). Practical path today: write one BLS `.conf` per profile with `options @N …` |
+| **rEFInd** | ✅ Autodetects `.efi` under `EFI/Linux/` | 🟡 Manual `refind.conf` entries per profile with `options "@N …"` — refind has no native profile awareness |
+| **GRUB** (2.14+) | 🟡 Chainload via `chainloader` directive | ❌ Multi-profile support [explicitly not present per release notes](https://forum.manjaro.org/t/grub-2-14-uki-support/184899) |
+| **limine** | 🟡 Manual `limine.conf` per UKI (no autodetect) | ❌ No profile awareness |
 
-Recommended flow per (snapshot × source UKI):
+The realistic picture: **multi-profile is currently a systemd-boot story.** The matrix should improve over time as bootloaders adopt the spec; cloned UKIs remain the universal fallback indefinitely.
+
+### Mode 1: Cloned UKIs per snapshot (default)
+
+**Output:** per (snapshot × source UKI), emit `<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi` containing:
+
+- `.linux` — same kernel as source (we don't rebuild kernels)
+- `.initrd` — same initramfs blob (microcode already concatenated)
+- `.osrel`, `.uname`, `.sbat` — copied from source
+- `.cmdline` — **rewritten** with `rootflags=subvol=…,subvolid=…` per snapshot
+
+**Build:** three editing strategies were tested empirically — only one works cleanly:
+
+| Strategy | Result |
+|---|---|
+| `objcopy --update-section .cmdline=newfile` | Truncates: new content cut to old section size. PE sections have fixed allocated size and can't grow in-place. |
+| `objcopy --remove-section .cmdline` + `--add-section` | Warns about PE layout integrity; uncertain without a real boot test. |
+| Extract sections via objcopy + rebuild via `ukify build` | Clean output, sha256-stable, valid by construction. **Recommended.** |
+
+Pseudocode per (snapshot × source UKI):
 
 ```bash
-# 1. Pull the immutable sections out of the source.
+mkdir tmp/
 objcopy -O binary --only-section=.linux  source.efi tmp/linux
 objcopy -O binary --only-section=.initrd source.efi tmp/initrd
 objcopy -O binary --only-section=.osrel  source.efi tmp/osrel
 objcopy -O binary --only-section=.uname  source.efi tmp/uname
 objcopy -O binary --only-section=.sbat   source.efi tmp/sbat   # if present
 
-# 2. Compute the per-snapshot cmdline using the same rewriter the bls binary uses.
-NEW_CMDLINE="$(internal/bls/snapshot.go:rewriteCmdline equivalent for UKI)"
-
-# 3. Rebuild via ukify, passing through the extracted sections and the new cmdline.
 ukify build \
-  --linux=tmp/linux \
-  --initrd=tmp/initrd \
-  --os-release=@tmp/osrel \
-  --uname="$(tr -d '\0' < tmp/uname)" \
+  --linux=tmp/linux --initrd=tmp/initrd \
+  --os-release=@tmp/osrel --uname="$(tr -d '\0' < tmp/uname)" \
   --sbat=@tmp/sbat \
-  --cmdline="$NEW_CMDLINE" \
+  --cmdline="$(rewriteCmdline)" \
   --output=<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi
 ```
 
-`ukify` ships with systemd (≥ v253). Detect at runtime; refuse cleanly with a pointer to the distro package (`systemd-ukify` on Arch, etc.) if missing.
-
-Practical concerns to surface in v1:
+**Costs/constraints:**
 
 | Concern | Mitigation |
 |---|---|
-| **Disk usage** — each UKI clone is a full ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `snapshot.selection_count` becomes load-bearing. Detect ESP free space before applying and refuse if insufficient. Surface the per-snapshot size in dry-run output. |
-| **Runtime dependency on `ukify`** | Detect at startup, error early with an actionable message. |
-| **Build cost** — ~2–3 s per UKI (compression dominates) | Progress logs per snapshot. Total for 25 snapshots: under a minute. Acceptable for a hourly-triggered service. |
-| **Microcode** | Source UKIs already concatenate microcode into the single `.initrd` section. Pass the extracted blob back to ukify verbatim — no microcode-specific handling needed. |
+| Each clone is ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `snapshot.selection_count` becomes load-bearing. Detect ESP free space before applying. |
+| Runtime dep on `ukify` (systemd ≥ v253) | Detect at startup; error early with package hint. |
+| Build cost ~2-3 s per UKI | Show per-snapshot progress logs. |
+
+### Mode 2: Multi-profile UKI (opt-in)
+
+**Output:** one `<esp>/EFI/Linux/<src-name>.efi` containing:
+
+- Base sections (`.linux`, `.initrd`, `.osrel`, `.uname`, `.sbat`) once
+- One `.profile` section per snapshot, each carrying its own `.cmdline` (a few hundred bytes vs. ~70 MB)
+- `.profile` metadata fields per [UAPI spec](https://uapi-group.org/specifications/specs/unified_kernel_image/):
+  - `ID=<snap-id>`
+  - `TITLE=<human-readable-snapshot-name>`
+
+The PE format defined by the UAPI spec: repeated `.profile` sections act as separators. Sections appearing before the first `.profile` are the base; sections between `.profile` markers belong to that profile. sd-stub measures only base + selected profile into PCR 12.
+
+**Build:** ukify natively supports this:
+
+```bash
+# 1. Build the base UKI as today (or take the system's existing UKI).
+# 2. For each snapshot, build a "mini-UKI" containing only its profile metadata
+#    and rewritten cmdline.
+ukify build \
+  --profile="ID=snap-N TITLE=Snapshot N (timestamp)" \
+  --cmdline="<rewritten>" \
+  --output=tmp/profile-N.efi
+
+# 3. Join the per-snapshot profiles into the base UKI in one shot.
+ukify build \
+  --linux=… --initrd=… --cmdline=<live cmdline> \
+  --join-profile=tmp/profile-1.efi \
+  --join-profile=tmp/profile-2.efi \
+  ... \
+  --output=<esp>/EFI/Linux/<src-name>.efi
+```
+
+**Selection at boot:** sd-stub strips a leading `@N ` from its invocation parameters and loads the matching profile. For systemd-boot, write BLS `.conf` entries with `options @1 ` etc. — the rest of the cmdline is supplied by the profile's own `.cmdline`.
+
+**Costs/constraints:**
+
+| Concern | Mitigation |
+|---|---|
+| Only useful if the boot path actually passes `@N` | Detect: if firmware-direct-boot is the active path, refuse cleanly with a message saying "your boot path doesn't support multi-profile UKIs; switch to mode 1 (clone)". |
+| Replaces the original UKI in place — `kernel-install` may overwrite | Hook into `kernel-install` (provide a `90-uki-btrfs-snapshots.install` script) to re-join profiles after kernel upgrades. |
+| Requires ukify ≥ 256 for `--join-profile` | Detect at startup. |
+| Per-snapshot BLS entries with `options @N ` are still needed for systemd-boot's menu | Write them alongside, same as the bls binary's existing flow. |
 
 ### Secure Boot
 
-**ukify natively handles Secure Boot signing** — we don't reimplement anything. Relevant flags:
+ukify natively handles SB signing for **both** modes. We just plumb config keys and forward as flags:
 
 | ukify flag | Purpose |
 |---|---|
-| `--secureboot-private-key=PATH` | Private key for the PE signature |
-| `--secureboot-certificate=PATH` | Cert for the PE signature |
-| `--signtool={sbsign,pesign,systemd-sbsign}` | Choose the signing backend |
-| `--sign-kernel` / `--no-sign-kernel` | Sign the embedded kernel separately (some SB shim configurations want this) |
-| `--pcr-private-key=PATH` | Private key for PCR signing (TPM2 measured boot) |
-| `--pcr-public-key=PATH` / `--pcr-certificate=PATH` | Verification material for PCR sigs |
+| `--secureboot-private-key=PATH`, `--secureboot-certificate=PATH` | PE signature material |
+| `--signtool={sbsign,pesign,systemd-sbsign}` | Signing backend |
+| `--sign-kernel` / `--no-sign-kernel` | Sign the embedded kernel separately (some shim configurations want this) |
+| `--pcr-private-key=PATH`, `--pcr-public-key=PATH`, `--pcr-certificate=PATH` | PCR signing for TPM2 measured boot |
+| `--sign-profile=ID` | Sign PCR measurements for a specific profile (mode 2) |
 | `--measure` / `--no-measure` | Whether to compute PCR measurements during build |
-| `--sign-profile ID` | Which PCR profile to sign |
 
-So once we plumb config keys for these (`uki.signing.key_path`, `uki.signing.cert_path`, `uki.signing.signtool`, `uki.pcr.key_path`, etc.) and forward them as ukify flags, Secure Boot support is essentially free.
+**Layered rollout:**
 
-**Layered rollout** (do less initially, add more if anyone asks):
-
-- **Initial:** detect Secure Boot via `/sys/firmware/efi/efivars/SecureBoot-*`; if enabled and signing config is absent, refuse cleanly with a message pointing at the signing config keys. Don't silently ship unsigned UKIs the firmware will reject.
-- **With signing:** wire the signing config through. The user provides their existing SB key/cert (the same ones their `kernel-install` setup uses), and the per-snapshot UKIs get signed identically.
-- **With PCR:** PCR signing for measured-boot setups. Note: changing the cmdline changes the PCR measurements, so TPM-sealed disks would fail to unlock for a snapshot-booted system unless the user's PCR policy explicitly enrolls the snapshot UKIs. Fiddly; wants opt-in plus clear docs.
+- **Initial:** detect Secure Boot via `/sys/firmware/efi/efivars/SecureBoot-*`; if enabled and signing config is absent, refuse cleanly. Don't silently ship unsigned UKIs the firmware will reject.
+- **With signing:** wire the signing config through. User supplies their existing SB key/cert (the same ones their `kernel-install` setup uses); per-snapshot UKIs (mode 1) or the joined UKI (mode 2) get signed identically.
+- **With PCR:** mode 2 has an edge here — sd-stub measures the selected profile into PCR 12, so the **same UKI** can have different PCR values per profile and unlock different TPM-sealed policies. Mode 1 is harder: each clone has different overall PCR measurements, so TPM-sealed disks need per-clone policy enrolment. Document the asymmetry; recommend mode 2 + PCR for TPM-sealed setups.
 
 ### Open questions
 
-- **Cleanup model:** how aggressively do we remove orphan UKI clones? The bls binary cleans up by prefix-match. Same pattern here, but with ~70 MB per file the consequences of leaving orphans around are different from the bls binary's ~1 KB `.conf` files.
-- **Naming:** does `bls-btrfs-snapshots-` style prefix apply, or do we use `uki-btrfs-snapshots-` to keep them clearly separable from any user-managed UKIs?
-- **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (e.g., shim-aware variants). Detect the source UKI's stub and reuse it, or always use the system stub? Probably reuse — preserves whatever security profile the original was built with.
-- **Cross-arch:** the systemd stub is per-arch. For aarch64 boxes we'd need `linuxaa64.efi.stub`. The matrix is already arch-aware (we build the binary for amd64/arm64); the runtime just picks the stub matching the running architecture.
-- **Coexistence with `kernel-install`:** distro `kernel-install` plugins regenerate the primary UKI on every kernel rebuild. Our managed clones (with the managed prefix) won't conflict with the primary, but we need to re-trigger after a kernel rebuild. The systemd `.path` unit watching `/.snapshots/` doesn't catch kernel rebuilds — we'd want a second trigger watching `/boot/EFI/Linux/` for source UKI changes. Worth thinking about before phase 3 ships.
+- **Mode selection:** static config (`uki.mode: clone | multi-profile`) or auto-detect from the boot path? Auto-detect is tempting but reading the active `BootXXXX` and inferring "this UKI was launched directly by firmware" is fragile. Prefer explicit config with a sensible default (`clone`).
+- **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.
+- **kernel-install coexistence:** distro `kernel-install` plugins regenerate the primary UKI on kernel upgrades, which clobbers any joined profiles. We need a kernel-install hook in mode 2 (and to detect+re-emit clones in mode 1). The systemd `.path` unit watching `/.snapshots/` doesn't fire on kernel rebuilds; need a second trigger watching `/boot/EFI/Linux/`.
+- **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (shim-aware variants). Detect the source UKI's stub and reuse it.
+- **Cross-arch:** stub is per-arch. amd64 binary already builds; aarch64 needs `linuxaa64.efi.stub`. Runtime picks the stub matching the running architecture.
+- **Naming:** managed prefix for mode 1 — `uki-btrfs-snapshots-` to keep clones clearly separable from user-managed UKIs.
+- **Reference implementations to watch:**
+  - [`hariganti/uki-btrfs`](https://github.com/hariganti/uki-btrfs) — Python tool for multi-profile UKIs, still WIP (no functional code at time of writing).
+  - [`openSUSE/sdbootutil`](https://github.com/openSUSE/sdbootutil) — production tool for BLS-on-snapper, uses unsigned-cmdline mode (different tradeoff).
+  - [CachyOS proof-of-concept](https://discuss.cachyos.org/t/proof-of-concept-full-btrfs-system-rollbacks-with-systemd-boot-using-uki-with-secureboot-enabled/15541) — explicitly noted as weakening Secure Boot guarantees.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -89,23 +89,36 @@ This comfortably fits a 512 MB ESP with room for other content. The pre-flight c
 
 **Reconciliation, not append.** Every run computes the desired set from scratch — covering both clones AND managed snapshot UKIs — scans the ESP under the managed prefix, and reconciles:
 
-1. **Desired set** is computed from the live system:
-   - One managed snapshot UKI per currently-installed kernel (`uki-btrfs-snapshots-<kernel>.efi`)
-   - Clones for the eligible (non-stale, non-deleted) snapshots in the newest-N, named `uki-btrfs-snapshots-<snap-id>-<kernel>.efi` where `<kernel>` is the live kernel that owns that snapshot's boot set
+1. **Desired set** is computed by joining the live system inventory with the snapshot module inventory:
+   - **One managed snapshot UKI per kernel version that has any bootable snapshot.** A "kernel version" `<K>` qualifies for a managed UKI iff *either* the live system currently has kernel `<K>` installed *or* at least one retained snapshot has matching modules under `/lib/modules/<K>-*/`. This means a managed UKI persists as long as it's the boot path for at least one snapshot — even if the live system has since switched away from that kernel.
+   - **Clones** for the eligible (non-stale, non-deleted) snapshots in the newest-N, named `uki-btrfs-snapshots-<snap-id>-<kernel>.efi` where `<kernel>` is the version whose managed UKI hosts the matching profile.
 2. `to_delete = on_disk − desired` catches:
    - Clones that aged out of the newest-N window
    - Clones whose snapshot was pruned from btrfs (snapper rotation, manual delete)
-   - Clones whose snapshot became stale relative to the current kernel (the existing `stale_snapshot_action=delete` flow already excludes them from the eligible set, so reconciliation removes them)
-   - Managed snapshot UKIs for kernels that no longer exist on the live system (subject to the `uki.cleanup_removed_kernels` policy — see below)
+   - Clones whose snapshot became stale relative to the current kernel (the existing `stale_snapshot_action=delete` flow excludes them from the eligible set; reconciliation removes them)
+   - Managed snapshot UKIs for kernels that *no longer have any compatible snapshot* AND aren't installed on the live system anymore (true orphans — no data depends on them)
 3. `to_add = desired − on_disk` catches:
    - Clones for new snapshots
    - Managed snapshot UKIs for newly-installed kernels
-   - Managed snapshot UKIs whose underlying live UKI's mtime changed (kernel upgrade)
+   - Managed snapshot UKIs whose underlying live UKI's mtime changed (kernel upgrade) — refresh from the new live UKI
 4. **Deletions are applied first**, freeing their space.
 5. **Then the pre-flight ESP free-space check runs against the additions only.**
 6. Refuse only if, *even after pruning aged-out files*, the new additions won't fit. Error: `ESP has X MB free after pruning, need Y MB for new artefacts. Reduce uki.clone.recent or free non-managed ESP files.`
 
-**`uki.cleanup_removed_kernels`** (default `false`): when a kernel is uninstalled (e.g., user switches from `linux-cachyos` to `linux-zen`), the managed snapshot UKI and clones for the removed kernel become orphans. Default behaviour is to **keep** them — they're recovery artefacts and removing them silently on a kernel switch is potentially destructive. `status` reports `recovery for removed kernel <name> available; remove with 'uki-btrfs-snapshots prune --removed-kernels'`. Set this to `true` to opt into automatic cleanup (typically only on lab/test systems).
+**Retention is principled, not opinionated.** The rule "a managed UKI exists iff at least one bootable snapshot needs it" handles every interesting case naturally:
+
+| Situation | Result |
+|---|---|
+| Live kernel A installed + snapshots compatible with A | Keep managed UKI; refresh on `kernel-install` updates via `.path` trigger |
+| Live kernel A uninstalled, but snapshots from before the uninstall still have `/lib/modules/<A>/` | **Keep** — those snapshots are still bootable via this UKI, which is now the *only* copy of kernel A on the system |
+| Live kernel A uninstalled AND no remaining snapshot has compatible modules | Remove — no data depends on it anymore |
+| Live kernel A installed + brand-new system, no snapshots yet | Keep — kernel is installed |
+
+**Bound on proliferation.** Each managed UKI only contains profiles for snapshots whose modules match its embedded kernel — a snapshot doesn't appear in two managed UKIs. So total profile count across all managed UKIs ≤ total eligible snapshot count. The disk cost scales with *distinct kernel versions* seen across the snapshot window, not with snapshot count. A user keeping 30 days of daily snapshots through 1-2 kernel upgrades has 1-2 managed UKIs (~70-140 MB), not one per snapshot.
+
+**The historical kernel preservation property is a side-effect.** When kernel A is uninstalled from the live system, our managed UKI for A becomes the **only** remaining copy of that kernel binary on disk — it's preserved inside the `.linux` PE section. This makes the managed UKI the authoritative recovery path for any snapshot that needs that kernel, until the last such snapshot is pruned. That's the right behaviour: the artefact's lifetime is bound to the data that depends on it.
+
+If a user wants more aggressive cleanup (e.g., test systems where stale kernels shouldn't accumulate), `uki.retain_only_installed_kernels: true` reverts to "managed UKI exists iff its kernel is currently installed on the live system" — orphans get removed even when snapshots reference them. Default is `false` (the data-driven policy above).
 
 This means the clone set **always tracks the newest N**, even on a tight ESP — there's no scenario where the binary silently degrades by refusing-and-doing-nothing while the safety net staleness grows. The only failure case is "even after pruning, the new set won't fit", which is the right time to refuse loudly.
 
@@ -113,7 +126,7 @@ This means the clone set **always tracks the newest N**, even on a tight ESP —
 
 - `cloned: 4 expected, 3 present (1 missing; last attempt refused due to ESP full)` — when reconciliation couldn't apply
 - `managed_uki: linux-cachyos missing (live UKI updated 2 days ago, regeneration failed)` — when a kernel-upgrade refresh got stuck
-- `removed_kernel: linux-cachyos has 4 recovery artefacts on disk; run prune to remove` — when `cleanup_removed_kernels=false` (default) and orphan recovery files exist
+- `retained_kernel: linux-cachyos (uninstalled from live system) — 4 snapshots still depend on it` — when a managed UKI is kept under the data-driven retention rule
 
 The refusal reason and orphan state are recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so they survive until the next successful run.
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -58,19 +58,17 @@ uki:
     # .cmdline differs). Cloning is per (snapshot × the kernel matching that
     # snapshot's modules), NOT per snapshot × every kernel.
     # 0 = unlimited (inherits snapshot.selection_count — caller beware).
-    recent: 4
+    recent: 3
 
     # Minimum clones per kernel that still has retained snapshots, in addition
-    # to whatever `recent` covers. Without this, immediately after a kernel
-    # upgrade the "newest 4" all become current-kernel and you lose any direct-
-    # bootable recovery clone for older kernels (the managed UKI's profile @0
-    # still covers them, but only for systemd-boot / sd-stub-aware paths).
-    # Setting `per_kernel_minimum: 1` guarantees at least one direct-bootable
-    # recovery target per historical kernel — they retire naturally as the
-    # underlying snapshots age out.
-    # 0 = no per-kernel guarantee (current behaviour); recommend 1 for systems
-    # where direct firmware boot is the recovery path.
-    per_kernel_minimum: 0
+    # to whatever `recent` covers. Default 1 guarantees at least one direct-
+    # bootable recovery target per historical kernel — without this, right after
+    # a kernel upgrade the "newest N" all become current-kernel and direct-
+    # firmware-boot loses access to older-kernel snapshots (multi-profile mode's
+    # @0 still covers them, but only via sd-stub-aware boot paths).
+    # Retires naturally as the underlying snapshots age out of btrfs retention.
+    # 0 = no per-kernel guarantee (only recency-driven clones).
+    per_kernel_minimum: 1
 
     # Optional hard cap on total clones across all kernels. Catches runaway
     # interaction between `recent` × many distinct kernels × `per_kernel_minimum`.
@@ -93,13 +91,13 @@ uki:
     cert_path: ""
 ```
 
-**Default footprint** for a single-kernel system with `clone.recent: 4`:
+**Default footprint** for a single-kernel system with the default `clone.recent: 3` and `clone.per_kernel_minimum: 1`:
 - Live UKI (kernel-install owned, untouched by us): **1 UKI on disk**
 - Managed snapshot UKI (us, contains all snapshot profiles): **1 UKI on disk**
-- Clones: **4 UKIs on disk**
-- **Total: 6 `.efi` files** (1 live + 1 managed snapshot + 4 clones).
+- Clones: **3 UKIs on disk** (per_kernel_minimum satisfied by the 3 recent clones since only 1 kernel)
+- **Total: 5 `.efi` files** (1 live + 1 managed + 3 clones).
 
-For a two-kernel system: one managed snapshot UKI per kernel + 4 shared clones = **8 `.efi` files** total.
+For multi-kernel systems, per_kernel_minimum adds one extra clone per historical kernel with retained snapshots — see the worked walk-through below.
 
 Each UKI is full-size (kernel + initrd embedded). Actual byte cost varies entirely with the distro's kernel and initramfs size and compression settings — measure on the target system before tuning the caps. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow.
 
@@ -146,18 +144,23 @@ This means the clone set **always tracks the newest N**, even on a tight ESP —
 
 The refusal reason and orphan state are recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so they survive until the next successful run.
 
-If the default is still too aggressive: setting `modes: [multi-profile]` drops the clone cost entirely; setting `clone.recent: 2` halves it; setting `modes: []` opts out.
+**Worked walk-through** — 3 kernel upgrades over 24 days, hourly + daily snapshots (24+24 retention). "Steady state" means a few days after the kernel change so the new kernel has accumulated >3 snapshots.
 
-If the default is **insufficient** — specifically, you want direct-firmware-boot access to recovery targets across kernel upgrades, not just to the most recent 4 snapshots — set `clone.per_kernel_minimum: 1`. Worked example for the 3-upgrades-in-24-days scenario (hourly + daily snapshots, 24+24 retention):
+| Phase | Managed UKIs | Clones (recent=3) | + per_kernel_min=1 adds | Total clones | Total `.efi` (managed + clones) |
+|---|---|---|---|---|---|
+| Day 7 (steady on A) | A | 3 A | — (A already covered) | 3 | **4** |
+| Day 12 (steady after A→B) | A, B | 3 B | 1 A | 4 | **6** |
+| Day 20 (steady after B→C) | A, B, C | 3 C | 1 B + 1 A | 5 | **8** |
+| Day 28 (steady after C→D) | A, B, C, D | 3 D | 1 C + 1 B + 1 A | 6 | **10** |
+| Day 32 (A snapshots pruned from btrfs) | B, C, D | 3 D | 1 C + 1 B | 5 | **8** |
 
-| Day | `per_kernel_minimum: 0` (default) | `per_kernel_minimum: 1` |
-|---|---|---|
-| 8 (after A→B) | 4 B-clones | 4 B + 1 A = 5 clones |
-| 16 (after B→C) | 4 C-clones | 4 C + 1 B + 1 A = 6 clones |
-| 24 (after C→D) | 4 D-clones | 4 D + 1 C + 1 B + 1 A = 7 clones |
-| 32 (A snaps pruned) | 4 D-clones | 4 D + 1 C + 1 B = 6 clones — A naturally retires |
+(Plus the kernel-install-owned live UKI, untouched — add 1 to each row for total ESP UKI count.)
 
-`per_kernel_minimum: 1` adds one full UKI's worth of disk per still-bootable historical kernel; they retire as the underlying snapshots age out of btrfs retention.
+Clone count grows with kernel diversity in the snapshot window, not with snapshot count. Historical-kernel clones retire automatically when the last compatible snapshot ages out of btrfs retention.
+
+If the footprint is too aggressive: `modes: [multi-profile]` drops all clones; `clone.recent: 2` reduces the recency window; `clone.per_kernel_minimum: 0` removes the per-kernel safety net (reverts to recency-only). If still too much, set `modes: []` to opt out.
+
+If you want a hard upper bound regardless of how many kernels are in play, set `clone.maximum_total: N`.
 
 The implementation note: mode 2's managed UKI is a separate file from the kernel-install-owned live UKI. We never modify the live UKI in place; this avoids the kernel-install clobber race entirely. On kernel upgrades, our `.path` unit (watching the live UKI's mtime in addition to `/.snapshots/`) regenerates the managed snapshot UKI from the new live UKI. No "repair" step is needed because we always rebuild from scratch.
 
@@ -321,7 +324,7 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 - **Both modes enabled by default**, gated only by package install. Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here. The mandatory pre-flight ESP free-space check (which sizes from the actual UKI on disk, not from any baked-in assumption) is the safety net against tight ESPs. Users wanting to tune down: set `modes: [clone]`, `modes: [multi-profile]`, `clone.recent: 2`, or `modes: []` to opt out entirely.
 - **Pre-flight space check operates against additions only**, after pruning aged-out clones (`desired − on_disk` and `on_disk − desired` computed each run; deletions applied first). Refusal happens only if even the post-pruning projection won't fit. This prevents the rollback safety net from silently degrading over time when the ESP is tight.
 - **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
-- **`uki.clone.recent` default of 4:** chosen conservatively because the actual byte cost depends on the host's UKI size, which we can't predict. Four clones is a reasonable compromise between "useful recovery set" and "doesn't blindly fill the ESP on hosts with large UKIs". Dry-run output should show the real numbers (actual UKI size × proposed clone count) so users see what they'd commit to before raising the cap.
+- **`uki.clone.recent` default of 3, `per_kernel_minimum` default of 1:** chosen so the default is opinionated-but-modest. Three recent clones for the current kernel cover "the very recent past went sideways" rollback; one-per-historical-kernel-with-snapshots covers "I want a direct-firmware-bootable recovery target for every still-bootable kernel". Total clone count = recent + (distinct historical kernels with snapshots) — stays bounded by kernel diversity in the snapshot window, not snapshot count. Dry-run output should show real numbers (actual UKI size × projected clone count) so users see what they'd commit to before raising the cap.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.
 - **kernel-install coexistence:** mode 2's separate managed snapshot UKI sidesteps the clobber problem entirely — kernel-install owns the live UKI; we own the snapshot UKI; the two never overlap. On kernel updates, `kernel-install` regenerates the live UKI as normal, and our `.path` unit (watching live-UKI mtime in addition to `/.snapshots/`) regenerates the snapshot UKI from the new kernel/initrd. Mode 1's clones also need refresh after kernel upgrades — same `.path` trigger handles both.
 - **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (shim-aware variants). Detect the source UKI's stub and reuse it.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -87,17 +87,35 @@ For two-kernel systems: ~420 MB additional (one managed snapshot UKI per kernel 
 
 This comfortably fits a 512 MB ESP with room for other content. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow.
 
-**Reconciliation, not append.** Every run computes the desired clone set from scratch (newest N snapshots), scans the ESP under the managed prefix, and reconciles:
+**Reconciliation, not append.** Every run computes the desired set from scratch — covering both clones AND managed snapshot UKIs — scans the ESP under the managed prefix, and reconciles:
 
-1. `to_delete = on_disk − desired` — old clones that aged out of the newest-N window, or clones whose source UKI's cmdline changed.
-2. `to_add = desired − on_disk` — clones for new snapshots not yet on disk.
-3. **Deletions are applied first**, freeing their space.
-4. **Then the pre-flight ESP free-space check runs against the additions only.**
-5. Refuse only if, *even after pruning aged-out clones*, the new additions won't fit. Error: `ESP has X MB free after pruning, need Y MB for new clones. Reduce uki.clone.recent or free non-managed ESP files.`
+1. **Desired set** is computed from the live system:
+   - One managed snapshot UKI per currently-installed kernel (`uki-btrfs-snapshots-<kernel>.efi`)
+   - Clones for the eligible (non-stale, non-deleted) snapshots in the newest-N, named `uki-btrfs-snapshots-<snap-id>-<kernel>.efi` where `<kernel>` is the live kernel that owns that snapshot's boot set
+2. `to_delete = on_disk − desired` catches:
+   - Clones that aged out of the newest-N window
+   - Clones whose snapshot was pruned from btrfs (snapper rotation, manual delete)
+   - Clones whose snapshot became stale relative to the current kernel (the existing `stale_snapshot_action=delete` flow already excludes them from the eligible set, so reconciliation removes them)
+   - Managed snapshot UKIs for kernels that no longer exist on the live system (subject to the `uki.cleanup_removed_kernels` policy — see below)
+3. `to_add = desired − on_disk` catches:
+   - Clones for new snapshots
+   - Managed snapshot UKIs for newly-installed kernels
+   - Managed snapshot UKIs whose underlying live UKI's mtime changed (kernel upgrade)
+4. **Deletions are applied first**, freeing their space.
+5. **Then the pre-flight ESP free-space check runs against the additions only.**
+6. Refuse only if, *even after pruning aged-out files*, the new additions won't fit. Error: `ESP has X MB free after pruning, need Y MB for new artefacts. Reduce uki.clone.recent or free non-managed ESP files.`
+
+**`uki.cleanup_removed_kernels`** (default `false`): when a kernel is uninstalled (e.g., user switches from `linux-cachyos` to `linux-zen`), the managed snapshot UKI and clones for the removed kernel become orphans. Default behaviour is to **keep** them — they're recovery artefacts and removing them silently on a kernel switch is potentially destructive. `status` reports `recovery for removed kernel <name> available; remove with 'uki-btrfs-snapshots prune --removed-kernels'`. Set this to `true` to opt into automatic cleanup (typically only on lab/test systems).
 
 This means the clone set **always tracks the newest N**, even on a tight ESP — there's no scenario where the binary silently degrades by refusing-and-doing-nothing while the safety net staleness grows. The only failure case is "even after pruning, the new set won't fit", which is the right time to refuse loudly.
 
-**Surfacing staleness.** The `status` command knows the desired set (from config + snapshot inventory) and the actual on-disk set. If they diverge, status reports e.g. `cloned: 4 expected, 3 present (1 missing; last attempt refused due to ESP full)`. The refusal reason is recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so it survives until the next successful run.
+**Surfacing staleness and orphans.** The `status` command knows the desired set (from config + snapshot inventory + installed kernels) and the actual on-disk set. If they diverge, status reports:
+
+- `cloned: 4 expected, 3 present (1 missing; last attempt refused due to ESP full)` — when reconciliation couldn't apply
+- `managed_uki: linux-cachyos missing (live UKI updated 2 days ago, regeneration failed)` — when a kernel-upgrade refresh got stuck
+- `removed_kernel: linux-cachyos has 4 recovery artefacts on disk; run prune to remove` — when `cleanup_removed_kernels=false` (default) and orphan recovery files exist
+
+The refusal reason and orphan state are recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so they survive until the next successful run.
 
 If the default is still too aggressive: setting `modes: [multi-profile]` alone drops to ~0 MB additional (in-place only); setting `clone.recent: 2` halves the clone cost; setting `modes: []` opts out entirely.
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -84,7 +84,19 @@ uki:
 
 For two-kernel systems: still ~280 MB (multi-profile is in-place on both live UKIs; 4 clones map to whichever kernel each clone's snapshot was taken under — typically the current kernel for recent snapshots). 6 `.efi` files total.
 
-This comfortably fits a 512 MB ESP with room for other content. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow — the binary refuses to apply with `ESP has X MB free, need Y MB. Reduce uki.clone.recent or free space.`
+This comfortably fits a 512 MB ESP with room for other content. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow.
+
+**Reconciliation, not append.** Every run computes the desired clone set from scratch (newest N snapshots), scans the ESP under the managed prefix, and reconciles:
+
+1. `to_delete = on_disk − desired` — old clones that aged out of the newest-N window, or clones whose source UKI's cmdline changed.
+2. `to_add = desired − on_disk` — clones for new snapshots not yet on disk.
+3. **Deletions are applied first**, freeing their space.
+4. **Then the pre-flight ESP free-space check runs against the additions only.**
+5. Refuse only if, *even after pruning aged-out clones*, the new additions won't fit. Error: `ESP has X MB free after pruning, need Y MB for new clones. Reduce uki.clone.recent or free non-managed ESP files.`
+
+This means the clone set **always tracks the newest N**, even on a tight ESP — there's no scenario where the binary silently degrades by refusing-and-doing-nothing while the safety net staleness grows. The only failure case is "even after pruning, the new set won't fit", which is the right time to refuse loudly.
+
+**Surfacing staleness.** The `status` command knows the desired set (from config + snapshot inventory) and the actual on-disk set. If they diverge, status reports e.g. `cloned: 4 expected, 3 present (1 missing; last attempt refused due to ESP full)`. The refusal reason is recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so it survives until the next successful run.
 
 If the default is still too aggressive: setting `modes: [multi-profile]` alone drops to ~0 MB additional (in-place only); setting `clone.recent: 2` halves the clone cost; setting `modes: []` opts out entirely.
 
@@ -230,7 +242,8 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 
 ### Open questions
 
-- **Both modes enabled by default**, gated only by package install (≈770 MB ESP footprint for the default single-kernel + 25-snapshot setup). Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here because the disk cost is large enough that silent overflow would be worse than an explicit pre-flight refusal. The pre-flight ESP free-space check is **mandatory**, not advisory — refuse to apply if projected size doesn't fit, with the exact numbers in the error message. Users wanting to tune down: set `modes: [clone]` or `modes: [multi-profile]` or `modes: []`.
+- **Both modes enabled by default**, gated only by package install (≈280 MB ESP footprint for the default single-kernel + 25-snapshot + `clone.recent: 4` setup). Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here. Users wanting to tune down: set `modes: [clone]`, `modes: [multi-profile]`, `clone.recent: 2`, or `modes: []` to opt out entirely.
+- **Pre-flight space check operates against additions only**, after pruning aged-out clones (`desired − on_disk` and `on_disk − desired` computed each run; deletions applied first). Refusal happens only if even the post-pruning projection won't fit. This prevents the rollback safety net from silently degrading over time when the ESP is tight.
 - **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
 - **`uki.clone.recent` default of 4:** chosen for ~280 MB headroom on a 512 MB ESP (the smaller-end size that still occurs in the wild). Yields 5 `.efi` files total on a single-kernel system (1 live multi-profile UKI + 4 clones). Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to before raising the cap.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -46,20 +46,28 @@ The two are not mutually exclusive. Plausible combinations:
 
 ```yaml
 uki:
-  # Which mode(s) to apply. Both are independent; you can enable either or both.
-  modes: [clone]                      # default; alternatives: [multi-profile], [clone, multi-profile]
+  # Which mode(s) to apply. Both are independent; both are enabled by default
+  # so installing the binary gives you the full coverage matrix: multi-profile
+  # for systemd-boot menu integration with sd-stub, plus 10 universal-fallback
+  # clones for direct-firmware boot or systemd-boot menu recovery.
+  modes: [clone, multi-profile]
 
   clone:
-    # Cap on how many snapshots get cloned. Cloning is expensive (~70 MB each)
-    # so this defaults conservatively; ESPs are typically 512 MB - 1 GB. The
-    # binary refuses to apply if the resulting set wouldn't fit alongside what's
-    # already on the ESP.
-    # 0 = inherit snapshot.selection_count (caller beware).
+    # Cap on how many snapshots get cloned. Cloning is expensive (~70 MB each
+    # before compression) so this defaults conservatively; ESPs are typically
+    # 512 MB - 1 GB. The binary runs a mandatory pre-flight ESP free-space
+    # check and refuses to apply if the projected set wouldn't fit alongside
+    # what's already on the ESP. Pick whichever boot-set's kernel each cloned
+    # snapshot was taken under; cloning is per (snapshot × associated kernel),
+    # not per snapshot × every kernel.
+    # 0 = unlimited (inherits snapshot.selection_count — caller beware).
     recent: 10
 
   multi_profile:
-    # Cap on how many profiles join the base UKI. Profiles cost a few KB each
-    # so this can run unlimited safely in normal cases.
+    # Cap on profiles joined to the base UKI. One base UKI per kernel; each
+    # carries one .profile section per eligible snapshot. Profiles are cheap
+    # (~few KB each) so this defaults unlimited — the practical cap is
+    # snapshot.selection_count.
     # 0 = inherit snapshot.selection_count.
     recent: 0
 
@@ -68,6 +76,17 @@ uki:
     key_path: ""
     cert_path: ""
 ```
+
+**Default footprint** for a single-kernel system with 25 selected snapshots:
+- 1 multi-profile UKI ≈ 70 MB (kernel + initrd shared; 25 profiles add ~50 KB total)
+- 10 clones × ~70 MB ≈ 700 MB
+- **Total ≈ 770 MB on the ESP.**
+
+For two-kernel systems: 2 multi-profile UKIs (one per kernel) + 10 clones associated with whichever kernel each clone's snapshot was taken under (clones aren't multiplied per kernel) ≈ 840 MB.
+
+The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow — the binary refuses to apply with `ESP has X MB free, need Y MB. Reduce uki.clone.recent or free space.`
+
+If the default footprint is too aggressive: setting `modes: [clone]` alone drops the multi-profile UKI overhead (~70 MB per kernel); setting `modes: [multi-profile]` alone reduces the total to a single multi-profile UKI per kernel (~70 MB regardless of snapshot count); setting `modes: []` opts out entirely.
 
 #### Profile display names
 
@@ -209,6 +228,7 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 
 ### Open questions
 
+- **Both modes enabled by default**, gated only by package install (≈770 MB ESP footprint for the default single-kernel + 25-snapshot setup). Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here because the disk cost is large enough that silent overflow would be worse than an explicit pre-flight refusal. The pre-flight ESP free-space check is **mandatory**, not advisory — refuse to apply if projected size doesn't fit, with the exact numbers in the error message. Users wanting to tune down: set `modes: [clone]` or `modes: [multi-profile]` or `modes: []`.
 - **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
 - **`uki.clone.recent` default of 10:** chosen for ~700 MB headroom on a typical 1 GB ESP. Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -78,11 +78,12 @@ uki:
 ```
 
 **Default footprint** for a single-kernel system with 25 selected snapshots:
-- Multi-profile: **0 MB additional** — operates in-place on the live UKI, only adds ~50 KB of `.profile` sections (kernel + initrd remain a single shared copy)
-- Clones: **4 × ~70 MB ≈ 280 MB** new files
-- **Total ≈ 280 MB additional disk, 5 `.efi` files on the ESP** (1 live multi-profile UKI + 4 cloned UKIs).
+- Live UKI (kernel-install owned): ~70 MB — **untouched by us**
+- Managed snapshot UKI (us): ~70 MB (clone of live UKI + 25 profile sections, ~50 KB metadata overhead)
+- Clones: **4 × ~70 MB ≈ 280 MB**
+- **Total ≈ 350 MB additional disk, 6 `.efi` files on the ESP** (1 live UKI + 1 managed snapshot UKI + 4 cloned UKIs).
 
-For two-kernel systems: still ~280 MB (multi-profile is in-place on both live UKIs; 4 clones map to whichever kernel each clone's snapshot was taken under — typically the current kernel for recent snapshots). 6 `.efi` files total.
+For two-kernel systems: ~420 MB additional (one managed snapshot UKI per kernel + 4 shared clones). 8 `.efi` files total.
 
 This comfortably fits a 512 MB ESP with room for other content. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow.
 
@@ -100,7 +101,7 @@ This means the clone set **always tracks the newest N**, even on a tight ESP —
 
 If the default is still too aggressive: setting `modes: [multi-profile]` alone drops to ~0 MB additional (in-place only); setting `clone.recent: 2` halves the clone cost; setting `modes: []` opts out entirely.
 
-The implementation note that makes mode 2 free: ukify's `--join-profile` lets us inject profile sections into the **existing** live UKI rather than write a parallel file. kernel-install will clobber those profile sections on every kernel upgrade, so the package ships a `90-uki-btrfs-snapshots.install` kernel-install hook that re-runs the join after each kernel update.
+The implementation note: mode 2's managed UKI is a separate file from the kernel-install-owned live UKI. We never modify the live UKI in place; this avoids the kernel-install clobber race entirely. On kernel upgrades, our `.path` unit (watching the live UKI's mtime in addition to `/.snapshots/`) regenerates the managed snapshot UKI from the new live UKI. No "repair" step is needed because we always rebuild from scratch.
 
 #### Profile display names
 
@@ -179,47 +180,64 @@ ukify build \
 
 ### Mode 2: Multi-profile UKI (opt-in)
 
-**Output:** one `<esp>/EFI/Linux/<src-name>.efi` containing:
+**Output:** a separate managed UKI per kernel at `<esp>/EFI/Linux/<prefix><kernel>.efi`, cloned from the live UKI and extended with one `.profile` section per eligible snapshot.
 
-- Base sections (`.linux`, `.initrd`, `.osrel`, `.uname`, `.sbat`) once
-- One `.profile` section per snapshot, each carrying its own `.cmdline` (a few hundred bytes vs. ~70 MB)
-- `.profile` metadata fields per [UAPI spec](https://uapi-group.org/specifications/specs/unified_kernel_image/):
-  - `ID=<snap-id>`
-  - `TITLE=<human-readable-snapshot-name>`
+**We do not modify the kernel-install-managed live UKI.** That file (`<esp>/EFI/Linux/<kernel>.efi`) is treated as read-only input; we only ever read from it to source the kernel/initrd/osrel/sbat sections. The managed snapshot UKI is a separate file owned entirely by this binary.
+
+**Profile ordering:**
+
+| Profile | Cmdline target | Why |
+|---|---|---|
+| `@0` (default) | **Most recent eligible snapshot** | Direct firmware boot of the snapshot UKI (`BootXXXX` entry) selects this — gives users a useful "panic-rollback" target without needing sd-stub's `@N` selector. The live UKI already handles "boot live root"; duplicating that as profile 0 would waste the slot. |
+| `@1`..`@N` | Each older eligible snapshot, newest-first | Selectable via sd-stub `@N` prefix from systemd-boot or hand-written refind entries. |
+
+Each profile carries its own `.cmdline` section plus `.profile` metadata per [UAPI spec](https://uapi-group.org/specifications/specs/unified_kernel_image/):
+- `ID=snap-<subvolid>` — used as the `@<ID>` selector
+- `TITLE=Linux-cachyos (2026-05-27T01:00:00Z)` — same title format the bls binary uses, honouring `advanced.naming.menu_format` + `display.local_time`
 
 The PE format defined by the UAPI spec: repeated `.profile` sections act as separators. Sections appearing before the first `.profile` are the base; sections between `.profile` markers belong to that profile. sd-stub measures only base + selected profile into PCR 12.
 
-**Build:** ukify natively supports this:
+**Build:**
 
 ```bash
-# 1. Build the base UKI as today (or take the system's existing UKI).
-# 2. For each snapshot, build a "mini-UKI" containing only its profile metadata
-#    and rewritten cmdline.
+# 1. For each profile (newest snapshot first), build a "mini-UKI" carrying
+#    only that profile's metadata and rewritten cmdline.
 ukify build \
-  --profile="ID=snap-N TITLE=Snapshot N (timestamp)" \
-  --cmdline="<rewritten>" \
-  --output=tmp/profile-N.efi
+  --profile="ID=snap-16403 TITLE=Linux-cachyos (2026-05-27T20:00Z)" \
+  --cmdline="<rewritten for snap 16403>" \
+  --output=tmp/profile-0.efi
+# … repeat for each snapshot, ordering = newest-first so profile @0 == newest
 
-# 3. Join the per-snapshot profiles into the base UKI in one shot.
+# 2. Build the managed snapshot UKI by joining all per-snapshot profiles onto
+#    a base assembled from the live UKI's sections (linux, initrd, osrel, uname,
+#    sbat extracted via objcopy).
 ukify build \
-  --linux=… --initrd=… --cmdline=<live cmdline> \
+  --linux=tmp/linux --initrd=tmp/initrd \
+  --os-release=@tmp/osrel --uname="$(tr -d '\0' < tmp/uname)" \
+  --sbat=@tmp/sbat \
+  --cmdline="<empty or trivial — profiles override>" \
+  --join-profile=tmp/profile-0.efi \
   --join-profile=tmp/profile-1.efi \
-  --join-profile=tmp/profile-2.efi \
   ... \
-  --output=<esp>/EFI/Linux/<src-name>.efi
+  --output=<esp>/EFI/Linux/<prefix><kernel>.efi
 ```
 
-**Selection at boot:** sd-stub strips a leading `@N ` from its invocation parameters and loads the matching profile. For systemd-boot, write BLS `.conf` entries with `options @1 ` etc. — the rest of the cmdline is supplied by the profile's own `.cmdline`.
+**Selection at boot:**
+
+- **Direct firmware boot:** if the firmware launches the managed snapshot UKI as a `BootXXXX` entry, profile `@0` (newest snapshot) is selected by default. Users wanting older snapshots without booting a different image use sd-stub or chainload via systemd-boot.
+- **systemd-boot:** auto-discovers the managed snapshot UKI; with native profile-menu synthesis (UAPI spec "may", depends on systemd-boot version) each profile becomes a menu entry. For deterministic menu population, write BLS `.conf` entries with `options @<ID> ` per profile (mirrors the bls binary's pattern).
+- **rEFInd:** treats the managed snapshot UKI as another EFI binary; per-profile selection needs hand-written `refind.conf` entries with `options "@<ID> "`.
 
 **Costs/constraints:**
 
 | Concern | Mitigation |
 |---|---|
-| Only useful if the boot path actually passes `@N` | Detect: if firmware-direct-boot is the active path, log a clear warning and recommend enabling `clone` alongside (modes is a list — they're additive). |
-| Replaces the original UKI in place — `kernel-install` may overwrite | Hook into `kernel-install` (provide a `90-uki-btrfs-snapshots.install` script) to re-join profiles after kernel upgrades. |
+| One extra UKI-sized file per kernel (~70 MB each) on the ESP | This is the cost of clean ownership separation from kernel-install. Accept and document. |
+| Snapshot UKI must stay in sync with live UKI's kernel/initrd after kernel updates | `.path` unit also watches mtime on `<esp>/EFI/Linux/<kernel>.efi`; when it changes (kernel-install ran), regenerate the snapshot UKI. No "repair" needed — just regenerate fresh. |
+| Only useful if the boot path actually passes `@N` (for profiles > 0) | Profile `@0 = newest snapshot` ensures direct firmware boot does something useful even without `@N` support. Log a notice if firmware-direct-boot is the active path, recommending also enabling `clone` for older snapshots. |
 | Requires ukify ≥ 256 for `--join-profile` | Detect at startup. |
-| Per-snapshot BLS entries with `options @N ` are still needed for systemd-boot's menu | Write them alongside, same as the bls binary's existing flow. |
-| Number of joined profiles bounded by `uki.multi_profile.recent` | Default unbounded — profiles are cheap (~KB), no realistic limit. Caps are only useful if a user wants the menu trimmed. |
+| Per-snapshot BLS entries with `options @<ID>` still useful for systemd-boot's menu | Optional; write them alongside if the user wants explicit menu entries beyond what systemd-boot may auto-synthesize. |
+| Number of joined profiles bounded by `uki.multi_profile.recent` | Default unbounded — profiles are cheap (~few KB each). |
 
 ### Secure Boot
 
@@ -247,7 +265,7 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 - **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
 - **`uki.clone.recent` default of 4:** chosen for ~280 MB headroom on a 512 MB ESP (the smaller-end size that still occurs in the wild). Yields 5 `.efi` files total on a single-kernel system (1 live multi-profile UKI + 4 clones). Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to before raising the cap.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.
-- **kernel-install coexistence:** distro `kernel-install` plugins regenerate the primary UKI on kernel upgrades, which clobbers any joined profiles. We need a kernel-install hook in mode 2 (and to detect+re-emit clones in mode 1). The systemd `.path` unit watching `/.snapshots/` doesn't fire on kernel rebuilds; need a second trigger watching `/boot/EFI/Linux/`.
+- **kernel-install coexistence:** mode 2's separate managed snapshot UKI sidesteps the clobber problem entirely — kernel-install owns the live UKI; we own the snapshot UKI; the two never overlap. On kernel updates, `kernel-install` regenerates the live UKI as normal, and our `.path` unit (watching live-UKI mtime in addition to `/.snapshots/`) regenerates the snapshot UKI from the new kernel/initrd. Mode 1's clones also need refresh after kernel upgrades — same `.path` trigger handles both.
 - **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (shim-aware variants). Detect the source UKI's stub and reuse it.
 - **Cross-arch:** stub is per-arch. amd64 binary already builds; aarch64 needs `linuxaa64.efi.stub`. Runtime picks the stub matching the running architecture.
 - **Naming:** managed prefix for mode 1 — `uki-btrfs-snapshots-` to keep clones clearly separable from user-managed UKIs.

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -60,12 +60,18 @@ uki:
     # 0 = unlimited (inherits snapshot.selection_count — caller beware).
     recent: 3
 
-    # Minimum clones per kernel that still has retained snapshots, in addition
-    # to whatever `recent` covers. Default 1 guarantees at least one direct-
-    # bootable recovery target per historical kernel — without this, right after
-    # a kernel upgrade the "newest N" all become current-kernel and direct-
-    # firmware-boot loses access to older-kernel snapshots (multi-profile mode's
-    # @0 still covers them, but only via sd-stub-aware boot paths).
+    # Minimum direct-bootable recovery targets per kernel that still has retained
+    # snapshots, on top of whatever `recent` covers. Default 1 guarantees one
+    # direct-firmware-bootable target per historical kernel.
+    #
+    # Implicitly satisfied by a managed UKI for the same kernel — when multi-
+    # profile mode is active, that managed UKI's profile @0 already boots the
+    # newest snapshot of its kernel under direct firmware boot (firmware has no
+    # @N selector so it always picks profile 0). So with modes: [clone,
+    # multi-profile] this knob effectively adds no extra clones (no double-up).
+    # With modes: [clone] alone, it adds 1 clone per historical kernel —
+    # the only direct-firmware path for those snapshots.
+    #
     # Retires naturally as the underlying snapshots age out of btrfs retention.
     # 0 = no per-kernel guarantee (only recency-driven clones).
     per_kernel_minimum: 1
@@ -144,21 +150,33 @@ This means the clone set **always tracks the newest N**, even on a tight ESP —
 
 The refusal reason and orphan state are recorded in a small state file under `/var/lib/uki-btrfs-snapshots/` so they survive until the next successful run.
 
-**Worked walk-through** — 3 kernel upgrades over 24 days, hourly + daily snapshots (24+24 retention). "Steady state" means a few days after the kernel change so the new kernel has accumulated >3 snapshots.
+**Worked walk-through** — 3 kernel upgrades over 24 days, hourly + daily snapshots (24+24 retention). "Steady state" = a few days after the kernel change so the new kernel has accumulated >3 snapshots.
 
-| Phase | Managed UKIs | Clones (recent=3) | + per_kernel_min=1 adds | Total clones | Total `.efi` (managed + clones) |
+With the default `modes: [clone, multi-profile]`: managed UKIs cover the "per-kernel direct-bootable target" need (each has profile @0 = newest snapshot for its kernel), so `per_kernel_minimum: 1` adds no extra clones. Each upgrade adds only the new kernel's managed UKI:
+
+| Phase | Managed UKIs | Recency clones | per_kernel_min adds | Total clones | Total `.efi` |
 |---|---|---|---|---|---|
-| Day 7 (steady on A) | A | 3 A | — (A already covered) | 3 | **4** |
-| Day 12 (steady after A→B) | A, B | 3 B | 1 A | 4 | **6** |
-| Day 20 (steady after B→C) | A, B, C | 3 C | 1 B + 1 A | 5 | **8** |
-| Day 28 (steady after C→D) | A, B, C, D | 3 D | 1 C + 1 B + 1 A | 6 | **10** |
-| Day 32 (A snapshots pruned from btrfs) | B, C, D | 3 D | 1 C + 1 B | 5 | **8** |
+| Day 7 (steady on A) | A | 3 A | — | 3 | **4** |
+| Day 12 (steady after A→B) | A, B | 3 B | — (A covered by managed UKI A) | 3 | **5** |
+| Day 20 (steady after B→C) | A, B, C | 3 C | — | 3 | **6** |
+| Day 28 (steady after C→D) | A, B, C, D | 3 D | — | 3 | **7** |
+| Day 32 (A's snapshots aged out) | B, C, D | 3 D | — | 3 | **6** |
 
-(Plus the kernel-install-owned live UKI, untouched — add 1 to each row for total ESP UKI count.)
+With `modes: [clone]` alone: no managed UKIs, so `per_kernel_minimum: 1` adds one clone per historical kernel as the only direct-firmware path:
 
-Clone count grows with kernel diversity in the snapshot window, not with snapshot count. Historical-kernel clones retire automatically when the last compatible snapshot ages out of btrfs retention.
+| Phase | Managed UKIs | Recency clones | per_kernel_min adds | Total `.efi` |
+|---|---|---|---|---|
+| Day 7 | — | 3 A | — | **3** |
+| Day 12 | — | 3 B | 1 A | **4** |
+| Day 20 | — | 3 C | 1 B + 1 A | **5** |
+| Day 28 | — | 3 D | 1 C + 1 B + 1 A | **6** |
+| Day 32 | — | 3 D | 1 C + 1 B | **5** |
 
-If the footprint is too aggressive: `modes: [multi-profile]` drops all clones; `clone.recent: 2` reduces the recency window; `clone.per_kernel_minimum: 0` removes the per-kernel safety net (reverts to recency-only). If still too much, set `modes: []` to opt out.
+(In both, add 1 for the kernel-install-owned live UKI on the ESP.)
+
+The two designs converge at "+1 per kernel upgrade" — once a kernel becomes historical it adds one artefact (either a managed UKI in mode 2, or a per_kernel_minimum clone in mode 1). Historical kernels retire automatically when their last compatible snapshot ages out of btrfs retention.
+
+If the footprint is too aggressive: `modes: [multi-profile]` drops all clones (only managed UKIs remain); `clone.recent: 2` reduces the recency window; `clone.per_kernel_minimum: 0` removes the per-kernel safety net for clone-only mode (irrelevant when multi-profile is also on). If still too much, set `modes: []` to opt out.
 
 If you want a hard upper bound regardless of how many kernels are in play, set `clone.maximum_total: N`.
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -53,15 +53,15 @@ uki:
   modes: [clone, multi-profile]
 
   clone:
-    # Cap on how many snapshots get cloned. Cloning is expensive (~70 MB each
-    # before compression) so this defaults conservatively; ESPs are typically
-    # 512 MB - 1 GB. The binary runs a mandatory pre-flight ESP free-space
+    # Cap on how many snapshots get cloned. Each clone is a full ~70 MB .efi
+    # file (kernel + initrd duplicated; only .cmdline differs from the source
+    # UKI). Pick whichever boot-set's kernel each cloned snapshot was taken
+    # under — cloning is per (snapshot × associated kernel), NOT per snapshot
+    # × every kernel. The binary runs a mandatory pre-flight ESP free-space
     # check and refuses to apply if the projected set wouldn't fit alongside
-    # what's already on the ESP. Pick whichever boot-set's kernel each cloned
-    # snapshot was taken under; cloning is per (snapshot × associated kernel),
-    # not per snapshot × every kernel.
+    # what's already on the ESP.
     # 0 = unlimited (inherits snapshot.selection_count — caller beware).
-    recent: 10
+    recent: 4
 
   multi_profile:
     # Cap on profiles joined to the base UKI. One base UKI per kernel; each
@@ -78,15 +78,17 @@ uki:
 ```
 
 **Default footprint** for a single-kernel system with 25 selected snapshots:
-- 1 multi-profile UKI ≈ 70 MB (kernel + initrd shared; 25 profiles add ~50 KB total)
-- 10 clones × ~70 MB ≈ 700 MB
-- **Total ≈ 770 MB on the ESP.**
+- Multi-profile: **0 MB additional** — operates in-place on the live UKI, only adds ~50 KB of `.profile` sections (kernel + initrd remain a single shared copy)
+- Clones: **4 × ~70 MB ≈ 280 MB** new files
+- **Total ≈ 280 MB additional disk, 5 `.efi` files on the ESP** (1 live multi-profile UKI + 4 cloned UKIs).
 
-For two-kernel systems: 2 multi-profile UKIs (one per kernel) + 10 clones associated with whichever kernel each clone's snapshot was taken under (clones aren't multiplied per kernel) ≈ 840 MB.
+For two-kernel systems: still ~280 MB (multi-profile is in-place on both live UKIs; 4 clones map to whichever kernel each clone's snapshot was taken under — typically the current kernel for recent snapshots). 6 `.efi` files total.
 
-The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow — the binary refuses to apply with `ESP has X MB free, need Y MB. Reduce uki.clone.recent or free space.`
+This comfortably fits a 512 MB ESP with room for other content. The pre-flight check makes "doesn't fit" a hard, actionable error rather than a silent overflow — the binary refuses to apply with `ESP has X MB free, need Y MB. Reduce uki.clone.recent or free space.`
 
-If the default footprint is too aggressive: setting `modes: [clone]` alone drops the multi-profile UKI overhead (~70 MB per kernel); setting `modes: [multi-profile]` alone reduces the total to a single multi-profile UKI per kernel (~70 MB regardless of snapshot count); setting `modes: []` opts out entirely.
+If the default is still too aggressive: setting `modes: [multi-profile]` alone drops to ~0 MB additional (in-place only); setting `clone.recent: 2` halves the clone cost; setting `modes: []` opts out entirely.
+
+The implementation note that makes mode 2 free: ukify's `--join-profile` lets us inject profile sections into the **existing** live UKI rather than write a parallel file. kernel-install will clobber those profile sections on every kernel upgrade, so the package ships a `90-uki-btrfs-snapshots.install` kernel-install hook that re-runs the join after each kernel update.
 
 #### Profile display names
 
@@ -158,7 +160,7 @@ ukify build \
 
 | Concern | Mitigation |
 |---|---|
-| Each clone is ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `uki.clone.recent` caps the count separately from `snapshot.selection_count`; default is 10 (≈700 MB). Pre-flight check: compute the required size and refuse if the ESP doesn't have headroom. |
+| Each clone is ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `uki.clone.recent` caps the count separately from `snapshot.selection_count`; default is 4 (≈280 MB) — fits a 512 MB ESP with headroom. Pre-flight check: compute the required size and refuse if the ESP doesn't have headroom. |
 | Runtime dep on `ukify` (systemd ≥ v253) | Detect at startup; error early with package hint. |
 | Build cost ~2-3 s per UKI | Show per-snapshot progress logs. |
 | Choosing which N to clone when `recent` < total snapshots | Newest-first by `SnapshotTime`. Same ordering the bls binary uses. |
@@ -230,7 +232,7 @@ ukify natively handles SB signing for **both** modes. We just plumb config keys 
 
 - **Both modes enabled by default**, gated only by package install (≈770 MB ESP footprint for the default single-kernel + 25-snapshot setup). Reasoning: this is the binary's *whole job*, and the user opted in by installing it; the bls binary's `write_entries: false` precedent isn't a fit here because the disk cost is large enough that silent overflow would be worse than an explicit pre-flight refusal. The pre-flight ESP free-space check is **mandatory**, not advisory — refuse to apply if projected size doesn't fit, with the exact numbers in the error message. Users wanting to tune down: set `modes: [clone]` or `modes: [multi-profile]` or `modes: []`.
 - **Mode selection:** explicit list config (`uki.modes: [clone, multi-profile]`) rather than auto-detect. Auto-detecting "your boot path uses direct firmware boot" is fragile (would need to walk EFI `BootXXXX`/`BootOrder` vars). Static config is simpler and lets users layer the two modes for belt-and-braces setups.
-- **`uki.clone.recent` default of 10:** chosen for ~700 MB headroom on a typical 1 GB ESP. Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to.
+- **`uki.clone.recent` default of 4:** chosen for ~280 MB headroom on a 512 MB ESP (the smaller-end size that still occurs in the wild). Yields 5 `.efi` files total on a single-kernel system (1 live multi-profile UKI + 4 clones). Worth surfacing actual snapshot+UKI sizes during dry-run so users see what they'd be committing to before raising the cap.
 - **Cleanup model:** mode 1 cleans by prefix-match (same as bls binary). Mode 2 has one UKI to rewrite; cleanup means stripping removed profiles — `ukify build` rebuild from scratch is simpler than surgical removal.
 - **kernel-install coexistence:** distro `kernel-install` plugins regenerate the primary UKI on kernel upgrades, which clobbers any joined profiles. We need a kernel-install hook in mode 2 (and to detect+re-emit clones in mode 1). The systemd `.path` unit watching `/.snapshots/` doesn't fire on kernel rebuilds; need a second trigger watching `/boot/EFI/Linux/`.
 - **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (shim-aware variants). Detect the source UKI's stub and reuse it.


### PR DESCRIPTION
## Summary

Docs-only PR refactoring the `uki-btrfs-snapshots` wishlist entry around two implementation modes — driven by your research input plus follow-up on bootloader/firmware support today.

## Key changes

- **Two modes, not one.** Previous wording assumed cloning was the only path. New structure:
  - **Mode 1 (default): cloned UKIs per snapshot** — ~70 MB each, but universal: every boot path can launch a `.efi`.
  - **Mode 2 (opt-in): multi-profile UKI** — ~few KB per snapshot via repeated `.profile` PE sections, but currently only systemd-boot reliably honours the `@N` profile selector.
- **Bootloader/firmware support matrix** — explicit table showing each consumer's status for cloned vs multi-profile. UEFI firmware direct-booting is the killer case for multi-profile: no `@N` selector means it always boots profile 0.
- **ukify pseudo-flows for both modes** — including `--profile` / `--join-profile` for multi-profile, which I verified locally is in current ukify (v260).
- **Secure Boot** section restructured — ukify handles signing for both modes; mode 2 has a TPM-sealed-disks advantage because sd-stub measures only the selected profile into PCR 12.
- **Open questions** updated — mode selection (auto-detect vs config), cleanup model differences, kernel-install coexistence (mode 2 risks clobber on kernel upgrades).
- Adds reference-implementations-to-watch section: hariganti/uki-btrfs (WIP), openSUSE/sdbootutil (production but unsigned-cmdline tradeoff), CachyOS PoC.

## Test plan

Docs-only. Renders correctly on GitHub.