### PR TITLE
feat(uki): sign_command + docs/distro templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Yes. If your system transitioned between boot configurations over time, older sn
 
 **Q: I use Unified Kernel Images (UKIs). Are they supported?**
 
-UKIs are **discovered and inspected** — they appear in `list bootsets`, `status`, and `kernel-spy`, and their embedded kernel version participates in staleness detection. We do **not** make snapshots bootable for UKI boot sets: a UKI's cmdline lives in its signed `.cmdline` PE section, and there's no general boot-loader-side override, so producing a snapshot boot entry would require rewriting (and re-signing under Secure Boot) the UKI per snapshot. That's tracked as a planned standalone `uki-btrfs-snapshots` binary — see [`docs/WISHLIST.md`](docs/WISHLIST.md).
+Yes, via the [`uki-btrfs-snapshots`](#related-binaries) sibling. It clones each source UKI per snapshot to `<esp>/EFI/Linux/<prefix><snap-id>-<src>.efi` with the `.cmdline` PE section rewritten to point at the snapshot's subvolume. Secure Boot signing is configurable via `uki.sign_command` — point it at [`peseal`](cmd/peseal/) (our pure-Go signer), `sbctl`, `sbsign`, `pesign`, or any custom script. Per-distro templates in the [cmd README](cmd/uki-btrfs-snapshots/README.md). For decoupled signing, install `peseal` and let its `.path` unit watch the ESP independently.
 
 **Q: I use systemd-boot's BLS `.conf` files. Do they affect anything?**
 
@@ -123,15 +123,15 @@ For rEFInd output, BLS-tagged boot sets are generated with the same shape as Spl
 
 ## Related binaries
 
-This repository ships three binaries built from a shared core (snapshot discovery, kernel/UKI inspection, fstab alignment, planner). Each one targets a different bootloader story; install the one(s) you need.
+This repository ships five binaries built from a shared core (snapshot discovery, kernel/UKI inspection, fstab alignment, planner). Each one targets a different boot story; install the one(s) you need.
 
 | Binary | Purpose | Released as |
 |---|---|---|
 | `refind-btrfs-snapshots` | Generate rEFInd `submenuentry` blocks for each snapshot. Supports both ESP-mode and btrfs-mode snapshots via rEFInd's btrfs driver. | AUR + GitHub Releases |
 | `bls-btrfs-snapshots` | Generate Boot Loader Specification Type #1 `.conf` entries under `<esp>/loader/entries/` for systemd-boot and BLS-aware GRUB. ESP-mode snapshots only. | GitHub Releases |
-| `kernel-spy` | Read-only diagnostic — dumps every kernel image, initramfs, microcode, BLS entry, and UKI the discovery layer can see on a host. Useful for debugging snapshot-bootability questions. | GitHub Releases |
-
-A planned `uki-btrfs-snapshots` binary that would make UKI hosts snapshot-bootable by cloning UKIs per snapshot is tracked in [`docs/WISHLIST.md`](docs/WISHLIST.md).
+| `uki-btrfs-snapshots` | Clone Unified Kernel Images per snapshot under `<esp>/EFI/Linux/`, rewriting `.cmdline` so each clone boots its snapshot's subvolume. Optional `sign_command` execs a signer per clone — see [distro templates](cmd/uki-btrfs-snapshots/README.md). | GitHub Releases |
+| `peseal` | Pure-Go Authenticode signer for PE32+ binaries (UKIs, EFI loaders). Wraps go-uefi for `sbctl`-compatible signatures. Idempotent; ships a `.path` unit for decoupled ESP watching. | GitHub Releases |
+| `kernel-spy` | Read-only diagnostic — dumps every kernel image, initramfs, microcode, BLS entry, and UKI the discovery layer can see on a host. | GitHub Releases |
 
 ## Links
 

--- a/cmd/uki-btrfs-snapshots/README.md
+++ b/cmd/uki-btrfs-snapshots/README.md
@@ -1,0 +1,55 @@
+# uki-btrfs-snapshots
+
+Clones source Unified Kernel Images per btrfs snapshot, rewriting each clone's `.cmdline` PE section so it boots its snapshot's subvolume. Optional `sign_command` exec re-signs each clone immediately after writing.
+
+## Signing options
+
+Clones are unsigned out of the box. On Secure Boot-enforcing systems you need to either:
+
+- **Inline signing** via `uki.sign_command` — execs a signer per clone during the same `generate` run.
+- **Decoupled signing** via [`peseal`](../peseal/) — `peseal.path` watches the output directory and signs whatever lands there independently of which tool wrote it.
+
+Decoupled is the recommended default — works for sdbootutil's primary UKIs and our clones equally. Inline is useful when you want the signing step visible in the same service run that wrote the clones.
+
+### Per-distro `sign_command` templates
+
+| Distro | Recommended | Template |
+|---|---|---|
+| Arch | `sbctl` or `peseal` | `["sbctl", "sign", "-s", "{}"]` |
+| Ubuntu | `sbsign` (sbsigntools) | `["sbsign", "--key", "/etc/secureboot/MOK.key", "--cert", "/etc/secureboot/MOK.crt", "--output", "{}", "{}"]` |
+| Fedora | `pesign` wrapper or `sbsign` | `["/usr/local/sbin/sign-uki-pesign", "{}"]` (script wraps pesign's two-file dance) |
+| Tumbleweed | `sbsign` or `systemd-sbsign` | `["sbsign", "--key", "/etc/sdbootutil/keys/db.key", "--cert", "/etc/sdbootutil/keys/db.crt", "--output", "{}", "{}"]` |
+| Any (peseal installed) | `peseal` | `["peseal", "sign", "{}"]` |
+
+The CLI also accepts a shell-quoted string form via `--sign-command`:
+
+```bash
+sudo uki-btrfs-snapshots generate --sign-command "peseal sign {}"
+```
+
+Same parsing as the YAML string form — split via shellwords.
+
+#### Fedora pesign wrapper
+
+pesign can't sign-in-place safely, so write a small wrapper at `/usr/local/sbin/sign-uki-pesign`:
+
+```sh
+#!/bin/sh
+pesign --sign --certificate uki-signing --in="$1" --out="$1.tmp"
+mv "$1.tmp" "$1"
+```
+
+`chmod +x` and reference it from `sign_command`. The wrapper isolates the temp-file dance from peseal's argv-based interface.
+
+### `{}` substitution semantics
+
+Exact-token match per argv element. `{}` becomes the clone's absolute path; `{}.sig`, `out={}`, and any other partial form pass through unchanged. If your tool needs an output-with-extension idiom, wrap it in a script as above.
+
+## Operational notes
+
+- **Dry-run** does not exec the sign command. `runner.Command` honours the runner's dry-run flag and just logs what would be exec'd.
+- **Per-clone failures aggregate.** If 2 of 5 clones fail to sign, the other 3 still get written + signed, and the binary exits non-zero with all five outcomes visible in the log.
+- **Idempotency depends on your signer.** `peseal` and `sbctl` skip files already signed by the configured cert. `sbsign` and `pesign` will overwrite the signature blob on each invocation (idempotent in content, but updates the file mtime — which can re-trigger `peseal.path` if both are configured).
+- **Order matters with sdbootutil.** If both sdbootutil and `uki-btrfs-snapshots` write to `/EFI/Linux/`, run sdbootutil first so the source UKI exists before clones are derived from it.
+
+See [`docs/USAGE.md`](../../docs/USAGE.md) for the broader configuration reference.

--- a/cmd/uki-btrfs-snapshots/generate.go
+++ b/cmd/uki-btrfs-snapshots/generate.go
@@ -35,6 +35,7 @@ func init() {
 	generateCmd.Flags().Bool("dry-run", false, "Show what would be written without making changes")
 	generateCmd.Flags().BoolP("yes", "y", false, "Automatically approve all changes without prompting")
 	generateCmd.Flags().Bool("force", false, "Force generation even if booted from a snapshot")
+	generateCmd.Flags().String("sign-command", "", "Shell-quoted command to exec per clone after writing; {} is substituted with the clone path (overrides uki.sign_command)")
 }
 
 func loadConfig(cmd *cobra.Command) (*config.Config, error) {
@@ -133,7 +134,16 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		diff.ShowPatchWithPager(patch, false)
 	}
 
-	if err := uki.Apply(out, r); err != nil {
+	signCommand := cfg.UKI.SignCommand.Argv()
+	if flagSign, _ := cmd.Flags().GetString("sign-command"); flagSign != "" {
+		argv, err := config.ParseShellArgv(flagSign)
+		if err != nil {
+			return fmt.Errorf("--sign-command: %w", err)
+		}
+		signCommand = argv
+	}
+
+	if err := uki.Apply(out, r, signCommand); err != nil {
 		return fmt.Errorf("apply UKI clones: %w", err)
 	}
 	log.Info().Int("clones", len(out.BinaryWrites)).Msg("UKI clones written")

--- a/configs/uki-btrfs-snapshots.yaml
+++ b/configs/uki-btrfs-snapshots.yaml
@@ -24,6 +24,41 @@ uki:
   # previous output so we never re-clone our own clones.
   entry_prefix: "uki-btrfs-snapshots-"
 
+  # Optional: exec a signing command after each clone is written. "{}" is
+  # substituted with the clone's absolute path. Unset → clones written
+  # unsigned (fine on SB-disabled systems).
+  #
+  # Accepts both list and string forms. Comment in the one that matches
+  # your signing tooling.
+  #
+  # peseal (sibling binary, pure-Go):
+  # sign_command: ["peseal", "sign", "{}"]
+  #
+  # sbctl (Arch — community repo, manages its own keystore):
+  # sign_command: ["sbctl", "sign", "-s", "{}"]
+  #
+  # sbsign (Ubuntu / cross-distro — explicit key + cert per invocation):
+  # sign_command:
+  #   - "sbsign"
+  #   - "--key"
+  #   - "/etc/secureboot/MOK.key"
+  #   - "--cert"
+  #   - "/etc/secureboot/MOK.crt"
+  #   - "--output"
+  #   - "{}"
+  #   - "{}"
+  #
+  # pesign (Fedora — needs a wrapper since it can't sign in-place safely):
+  # sign_command: ["/usr/local/sbin/sign-uki-pesign", "{}"]
+  #
+  # systemd-sbsign (Tumbleweed / systemd >= 254):
+  # sign_command:
+  #   - "systemd-sbsign"
+  #   - "sign"
+  #   - "--private-key=/etc/sdbootutil/keys/db.key"
+  #   - "--certificate=/etc/sdbootutil/keys/db.crt"
+  #   - "{}"
+
 # Snapshot discovery — identical to refind/bls.
 snapshot:
   search_directories:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -103,7 +103,7 @@ A drop-in `.conf` file under `<esp>/loader/entries/*.conf` describes the entry. 
 
 A single PE/EFI binary at `<esp>/EFI/Linux/<name>.efi` containing the kernel, initramfs, cmdline, and OS-release metadata. The systemd-stub launches the embedded kernel with the embedded cmdline. Spec: <https://uapi-group.org/specifications/specs/boot_loader_specification/#type-2-efi-unified-kernel-images>.
 
-**Discovery only — not snapshot-bootable.** We detect and inspect UKIs (they show up in `list bootsets`, `status`, and `kernel-spy`, and their embedded kernel version participates in staleness detection), but we do not produce snapshot boot entries for UKI boot sets. A snapshot-bootable cmdline is `rootflags=subvol=<snap>,subvolid=<id>`, and on a UKI that lives inside the signed `.cmdline` PE section — there's no generally-reliable boot-loader-side override, so making a snapshot bootable would require rewriting (and, under Secure Boot, re-signing) the UKI per snapshot. That's tracked as a planned standalone `uki-btrfs-snapshots` binary — see [`WISHLIST.md`](WISHLIST.md).
+**Discovery-only in this binary; snapshot booting handled by [`uki-btrfs-snapshots`](../cmd/uki-btrfs-snapshots/).** UKIs show up in `list bootsets`, `status`, and `kernel-spy`; their embedded kernel version participates in staleness detection. The `uki-btrfs-snapshots` sibling clones each source UKI per snapshot to `<esp>/EFI/Linux/<prefix><snap-id>-<src>.efi` with the `.cmdline` PE section rewritten to point at the snapshot's subvolume. Pure-Go via the in-repo `pkg/uki` library — no `ukify`/`objcopy` dependency. Secure Boot signing is configurable via `uki.sign_command` (or via the standalone [`peseal`](../cmd/peseal/) binary on a decoupled `.path` trigger).
 
 ## Commands
 
@@ -643,7 +643,8 @@ Shows: ESP detection, snapshot discovery, boot image scanning, kernel version in
 | BLS-aware GRUB  | `bls-btrfs-snapshots`            | ESP mode only        | Same `.conf` output; works wherever `GRUB_ENABLE_BLSCFG=true`.                                                   |
 | non-BLS GRUB    | (none yet)                       | —                    | Not currently planned.                                                                                           |
 | limine          | (none yet)                       | —                    | Not currently planned.                                                                                           |
-| UKI host        | (planned)                        | —                    | A `uki-btrfs-snapshots` binary that clones UKIs per snapshot is on the wishlist; see [WISHLIST.md](WISHLIST.md). |
+| UKI host        | `uki-btrfs-snapshots`            | ESP mode only        | Clones each source UKI per snapshot to `<esp>/EFI/Linux/` with the `.cmdline` rewritten. Optional `sign_command` execs a signer per clone (peseal/sbctl/sbsign/pesign — see [cmd README](../cmd/uki-btrfs-snapshots/README.md)). |
+| Authenticode    | `peseal`                         | n/a                  | Standalone PE signer. Watches `/boot/EFI/Linux` + `/boot/efi/EFI/Linux` via its `.path` unit and signs whatever lands there. Used by `uki-btrfs-snapshots` via `sign_command` or independently against any UKI/loader. |
 
 For inspecting what the discovery layer sees on a given host — useful regardless of which generator binary you use — the `kernel-spy` binary dumps every detected kernel image, initramfs, microcode blob, BLS entry, and UKI without modifying anything.
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -4,112 +4,41 @@ Planned features and capabilities that aren't built yet. Items here are **not co
 
 ## Table of Contents
 
-- [`uki-btrfs-snapshots` binary](#uki-btrfs-snapshots-binary)
-  - [Intention](#intention)
-  - [Outcome](#outcome)
-  - [Approach](#approach)
-  - [Secure Boot](#secure-boot)
-  - [Open questions](#open-questions)
+- [Hardware-backed signing keys (peseal)](#hardware-backed-signing-keys-peseal)
+- [PCR signing for TPM-sealed disks](#pcr-signing-for-tpm-sealed-disks)
+- [Open questions](#open-questions)
 
 ---
 
-## `uki-btrfs-snapshots` binary
+## Hardware-backed signing keys (peseal)
 
-A third sibling to `refind-btrfs-snapshots` and `bls-btrfs-snapshots` that makes btrfs snapshots bootable when the kernel is delivered as a UKI (Unified Kernel Image).
+`peseal` ships with software-key signing only — `pkg/authenticode.Signer` holds an `*rsa.PrivateKey` loaded from PEM. For users on enterprise SB setups, YubiKey-via-PKCS#11, or TPM2-stored keys, that's not enough.
 
-### Intention
+See [`cmd/peseal/TODO.md`](../cmd/peseal/TODO.md) for the full roadmap. Short version: the `Signer.key` field becoming `crypto.Signer` is the enabling refactor (go-uefi already accepts the interface), and per-backend wrappers come after:
 
-A UKI bundles kernel + initramfs + cmdline + os-release into a single signed PE binary that the firmware (or systemd-boot) can chainload directly. The cmdline lives **inside** the signed image as the `.cmdline` PE section, so neither the rEFInd nor the bls binary can make UKI-booting systems snapshot-bootable: they emit external bootloader config that proposes a cmdline, but the UKI ignores it. The cmdline that runs is whatever was baked into the UKI at build time.
+- **TPM2** via `github.com/google/go-tpm` — pure Go, covers the modal Tumbleweed/sdbootutil audience.
+- **PKCS#11** via `github.com/ThalesGroup/crypto11` or similar — requires CGO; gated behind a build tag to keep the default release CGO-free.
+- **PCR-bound policy auth** — TPM2 keys that only sign when the machine is in a specific measured-boot state.
 
-To make a snapshot bootable on a UKI-only system, we have to **produce a UKI per snapshot** with a per-snapshot cmdline embedded.
+The thorny operational issue is auth-material handling for non-interactive .service usage. The right answer is systemd `LoadCredentialEncrypted=` for PIN-bearing backends (PKCS#11, PIV) and PCR-policy-bound TPM2 keys for the "no secret at all" path. See [`cmd/peseal/TODO.md`](../cmd/peseal/TODO.md) for the full threat-model framing.
 
-### Outcome
+## PCR signing for TPM-sealed disks
 
-Per (snapshot × UKI source), emit one cloned UKI to `<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi` with:
+Authenticode signing (which peseal does) authenticates the UKI's bytes to the firmware. PCR signing is a separate concern: it signs predictions of what TPM PCR values **will** be when this specific UKI boots, so systemd-stub can unseal TPM-bound LUKS keys.
 
-- `.linux` — same kernel as the source UKI (we don't rebuild kernels)
-- `.initrd` — same initramfs blob (microcode already concatenated if the source had it)
-- `.osrel` — same os-release
-- `.uname` — same kernel version string
-- `.cmdline` — **rewritten** with `rootflags=subvol=<snap-path>,subvolid=<snap-id>` per snapshot
-- `.sbat` — same (revocation metadata; doesn't depend on cmdline)
+The signing primitive is the same; the hard part is generating correct PCR predictions, because that requires reimplementing systemd-stub's measurement logic (which lives in C and changes across systemd versions).
 
-Existing snapshot-fstab alignment (`internal/snapshotfs.UpdateFstabs`) applies unchanged.
+Three realistic paths, in order of preference:
 
-The binary follows the same shell as `bls-btrfs-snapshots`: cobra root + `generate`/`version` subcommands, opt-in `uki.write_entries` gate, dry-run / `--yes` / `--force` flags, the shared `cliconfig` + `internal/version` plumbing, the `internal/bootloader.Generator` interface, snapshot fstab alignment via the shared `snapshotfs` helper.
+1. **Shell out to `systemd-measure`** — pragmatic, breaks the pure-Go ethos. ~3 days of work, low maintenance.
+2. **Wait for upstream** — a Go library wrapping systemd-stub's measurement logic might emerge. Indefinite timeline.
+3. **Reimplement in pure Go** — 2-4 weeks of work plus ongoing maintenance to track systemd-stub changes upstream. Hard to justify for an audience that mostly already has systemd-measure installed.
 
-### Approach
+Defer until demonstrated demand. Document the `systemd-measure` recipe as an external step users can wire into their `peseal.path` chain or via a wrapper script.
 
-Three editing strategies were tested empirically:
+## Open questions
 
-| Strategy | Result | Verdict |
-|---|---|---|
-| `objcopy --update-section .cmdline=newfile` | Truncates: new content cut to old section size. PE sections have fixed allocated size and can't grow in-place. | Unusable — our rewritten cmdline is almost always longer than the source's |
-| `objcopy --remove-section .cmdline` + `--add-section` | Section size correct, but objcopy warns `section below image base`; PE layout integrity uncertain without a real boot test | Risky |
-| Extract sections via objcopy + rebuild via `ukify build` | Clean output, sha256-stable, valid UKI by construction (ukify handles section layout, alignment, signing path) | **Recommended** |
-
-Recommended flow per (snapshot × source UKI):
-
-```bash
-# 1. Pull the immutable sections out of the source.
-objcopy -O binary --only-section=.linux  source.efi tmp/linux
-objcopy -O binary --only-section=.initrd source.efi tmp/initrd
-objcopy -O binary --only-section=.osrel  source.efi tmp/osrel
-objcopy -O binary --only-section=.uname  source.efi tmp/uname
-objcopy -O binary --only-section=.sbat   source.efi tmp/sbat   # if present
-
-# 2. Compute the per-snapshot cmdline using the same rewriter the bls binary uses.
-NEW_CMDLINE="$(internal/bls/snapshot.go:rewriteCmdline equivalent for UKI)"
-
-# 3. Rebuild via ukify, passing through the extracted sections and the new cmdline.
-ukify build \
-  --linux=tmp/linux \
-  --initrd=tmp/initrd \
-  --os-release=@tmp/osrel \
-  --uname="$(tr -d '\0' < tmp/uname)" \
-  --sbat=@tmp/sbat \
-  --cmdline="$NEW_CMDLINE" \
-  --output=<esp>/EFI/Linux/<prefix><snap-id>-<src-name>.efi
-```
-
-`ukify` ships with systemd (≥ v253). Detect at runtime; refuse cleanly with a pointer to the distro package (`systemd-ukify` on Arch, etc.) if missing.
-
-Practical concerns to surface in v1:
-
-| Concern | Mitigation |
-|---|---|
-| **Disk usage** — each UKI clone is a full ~70 MB. 25 snapshots × ~70 MB ≈ 1.75 GB on the ESP. | `snapshot.selection_count` becomes load-bearing. Detect ESP free space before applying and refuse if insufficient. Surface the per-snapshot size in dry-run output. |
-| **Runtime dependency on `ukify`** | Detect at startup, error early with an actionable message. |
-| **Build cost** — ~2–3 s per UKI (compression dominates) | Progress logs per snapshot. Total for 25 snapshots: under a minute. Acceptable for a hourly-triggered service. |
-| **Microcode** | Source UKIs already concatenate microcode into the single `.initrd` section. Pass the extracted blob back to ukify verbatim — no microcode-specific handling needed. |
-
-### Secure Boot
-
-**ukify natively handles Secure Boot signing** — we don't reimplement anything. Relevant flags:
-
-| ukify flag | Purpose |
-|---|---|
-| `--secureboot-private-key=PATH` | Private key for the PE signature |
-| `--secureboot-certificate=PATH` | Cert for the PE signature |
-| `--signtool={sbsign,pesign,systemd-sbsign}` | Choose the signing backend |
-| `--sign-kernel` / `--no-sign-kernel` | Sign the embedded kernel separately (some SB shim configurations want this) |
-| `--pcr-private-key=PATH` | Private key for PCR signing (TPM2 measured boot) |
-| `--pcr-public-key=PATH` / `--pcr-certificate=PATH` | Verification material for PCR sigs |
-| `--measure` / `--no-measure` | Whether to compute PCR measurements during build |
-| `--sign-profile ID` | Which PCR profile to sign |
-
-So once we plumb config keys for these (`uki.signing.key_path`, `uki.signing.cert_path`, `uki.signing.signtool`, `uki.pcr.key_path`, etc.) and forward them as ukify flags, Secure Boot support is essentially free.
-
-**Layered rollout** (do less initially, add more if anyone asks):
-
-- **Initial:** detect Secure Boot via `/sys/firmware/efi/efivars/SecureBoot-*`; if enabled and signing config is absent, refuse cleanly with a message pointing at the signing config keys. Don't silently ship unsigned UKIs the firmware will reject.
-- **With signing:** wire the signing config through. The user provides their existing SB key/cert (the same ones their `kernel-install` setup uses), and the per-snapshot UKIs get signed identically.
-- **With PCR:** PCR signing for measured-boot setups. Note: changing the cmdline changes the PCR measurements, so TPM-sealed disks would fail to unlock for a snapshot-booted system unless the user's PCR policy explicitly enrolls the snapshot UKIs. Fiddly; wants opt-in plus clear docs.
-
-### Open questions
-
-- **Cleanup model:** how aggressively do we remove orphan UKI clones? The bls binary cleans up by prefix-match. Same pattern here, but with ~70 MB per file the consequences of leaving orphans around are different from the bls binary's ~1 KB `.conf` files.
-- **Naming:** does `bls-btrfs-snapshots-` style prefix apply, or do we use `uki-btrfs-snapshots-` to keep them clearly separable from any user-managed UKIs?
-- **Stub override:** ukify defaults to `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. Some users build UKIs with a custom stub (e.g., shim-aware variants). Detect the source UKI's stub and reuse it, or always use the system stub? Probably reuse — preserves whatever security profile the original was built with.
-- **Cross-arch:** the systemd stub is per-arch. For aarch64 boxes we'd need `linuxaa64.efi.stub`. The matrix is already arch-aware (we build the binary for amd64/arm64); the runtime just picks the stub matching the running architecture.
-- **Coexistence with `kernel-install`:** distro `kernel-install` plugins regenerate the primary UKI on every kernel rebuild. Our managed clones (with the managed prefix) won't conflict with the primary, but we need to re-trigger after a kernel rebuild. The systemd `.path` unit watching `/.snapshots/` doesn't catch kernel rebuilds — we'd want a second trigger watching `/boot/EFI/Linux/` for source UKI changes. Worth thinking about before phase 3 ships.
+- **Stub override for UKI clones.** `pkg/uki` round-trips whatever stub the source UKI was built with, preserving the original security profile. If a future use case wants to *change* the stub during cloning (e.g., swap in a shim-aware variant), we'd need section-level surgery beyond `.cmdline` rewrite. No concrete request yet.
+- **Per-snapshot ESP usage cap.** Each clone is ~70 MB. `snapshot.selection_count` becomes load-bearing on UKI-only systems. Worth a soft warning when planned writes would consume >X% of the ESP's free space, configurable via something like `uki.max_esp_usage_percent`.
+- **`.ucode` standalone microcode section.** Source UKIs today concatenate microcode into the single `.initrd` section; `pkg/uki` preserves that verbatim. If a vendor adopts the UAPI-listed `.ucode` standalone section, we'd need to confirm the round-trip still works.
+- **Cert-chain validation in `peseal verify`.** Current implementation accepts a signature if any supplied root matches. Real chain validation (intermediates, EKU constraints, expiry) would use `crypto/x509.Verify`. Out of scope until someone hits a real chain.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
+	github.com/mattn/go-shellwords v1.0.13 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-shellwords v1.0.13 h1:DC0OMEpGjm6LfNFU4ckYcvbQKyp2vE8atyFGXNtDcf4=
+github.com/mattn/go-shellwords v1.0.13/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,11 @@ type UKIConfig struct {
 	WriteEntries Truthy `koanf:"write_entries"`
 	OutputDir    string `koanf:"output_dir"`
 	EntryPrefix  string `koanf:"entry_prefix"`
+
+	// SignCommand, when non-empty, is exec'd per cloned UKI after writing.
+	// The literal "{}" in any argv element is substituted with the clone's
+	// absolute path before exec. Empty / nil → clones are written unsigned.
+	SignCommand ShellArgv `koanf:"sign_command"`
 }
 
 type AdvancedConfig struct {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -78,6 +78,7 @@ func Load(cfgFile string, flagOverrides map[string]any) (*Config, error) {
 		DecoderConfig: &mapstructure.DecoderConfig{
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
 				mapstructure.TextUnmarshallerHookFunc(),
+				shellArgvDecodeHook,
 				mapstructure.StringToSliceHookFunc(","),
 			),
 			Metadata:         nil,

--- a/internal/config/shellargv.go
+++ b/internal/config/shellargv.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mattn/go-shellwords"
+)
+
+// ShellArgv accepts both YAML shapes for command-line argv:
+//
+//	sign_command: ["peseal", "sign", "{}"]   # list form
+//	sign_command: "peseal sign {}"            # string form (shellwords-split)
+type ShellArgv []string
+
+func (s ShellArgv) Argv() []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+func ParseShellArgv(s string) ([]string, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return shellwords.Parse(s)
+}
+
+func shellArgvDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	if to != reflect.TypeOf(ShellArgv{}) || from.Kind() != reflect.String {
+		return data, nil
+	}
+	tokens, err := ParseShellArgv(data.(string))
+	if err != nil {
+		return nil, fmt.Errorf("sign_command: %w", err)
+	}
+	return ShellArgv(tokens), nil
+}

--- a/internal/config/shellargv_test.go
+++ b/internal/config/shellargv_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseShellArgv(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"peseal sign {}", []string{"peseal", "sign", "{}"}},
+		{`sbsign --key /etc/x --output "{}" "{}"`, []string{"sbsign", "--key", "/etc/x", "--output", "{}", "{}"}},
+		{`/usr/local/sbin/sign-uki "{}"`, []string{"/usr/local/sbin/sign-uki", "{}"}},
+	}
+	for _, tt := range tests {
+		got, err := ParseShellArgv(tt.in)
+		require.NoError(t, err, "input %q", tt.in)
+		assert.Equal(t, tt.want, got, "input %q", tt.in)
+	}
+}
+
+func TestLoad_SignCommand_ListForm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+uki:
+  write_entries: true
+  sign_command:
+    - peseal
+    - sign
+    - "{}"
+`), 0o644))
+
+	cfg, err := Load(path, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ShellArgv{"peseal", "sign", "{}"}, cfg.UKI.SignCommand)
+}
+
+func TestLoad_SignCommand_StringForm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+uki:
+  write_entries: true
+  sign_command: "peseal sign {}"
+`), 0o644))
+
+	cfg, err := Load(path, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ShellArgv{"peseal", "sign", "{}"}, cfg.UKI.SignCommand,
+		"string form must be shellwords-split into the same argv as the list form")
+}
+
+func TestLoad_SignCommand_AbsentMeansNil(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("uki:\n  write_entries: true\n"), 0o644))
+
+	cfg, err := Load(path, nil)
+	require.NoError(t, err)
+	assert.Empty(t, cfg.UKI.SignCommand)
+	assert.Nil(t, cfg.UKI.SignCommand.Argv(), "absent must read as nil so callers can short-circuit cleanly")
+}

--- a/internal/uki/bootloader.go
+++ b/internal/uki/bootloader.go
@@ -164,11 +164,11 @@ func fileSize(path string) int64 {
 	return info.Size()
 }
 
-// Apply writes every BinaryWrite via the runner and removes orphan
-// FileDiffs (IsNew=false, Modified=""). It exists because the byte
-// payloads can't go through diff.Apply — the text-diff pipeline would
-// mangle the binary on display and is only safe for descriptor diffs.
-func Apply(out *bootloader.Output, r runner.Runner) error {
+// Apply writes BinaryWrites, removes orphan FileDiffs (IsNew=false,
+// Modified=""), and if signCommand is non-empty, execs it per clone with
+// "{}" substituted to the clone's path. Lives outside diff.Apply because
+// the binary payloads can't survive the text-diff pipeline.
+func Apply(out *bootloader.Output, r runner.Runner, signCommand []string) error {
 	if out == nil {
 		return nil
 	}
@@ -182,6 +182,11 @@ func Apply(out *bootloader.Output, r runner.Runner) error {
 		if err := r.WriteFile(bw.Path, bw.Content, 0o644, bw.Description); err != nil {
 			errs = append(errs, fmt.Errorf("write %s: %w", bw.Path, err))
 			continue
+		}
+		if cmd := substituteTemplate(signCommand, bw.Path); len(cmd) > 0 {
+			if err := r.Command(cmd[0], cmd[1:], fmt.Sprintf("Sign %s", bw.Path)); err != nil {
+				errs = append(errs, fmt.Errorf("sign %s: %w", bw.Path, err))
+			}
 		}
 	}
 
@@ -204,4 +209,21 @@ func Apply(out *bootloader.Output, r runner.Runner) error {
 		return fmt.Errorf("UKI apply: %d failures: %w", len(errs), errors.Join(errs...))
 	}
 	return nil
+}
+
+// substituteTemplate replaces argv elements equal to "{}" with clonePath.
+// Exact-token match only — "{}.sig" and "out={}" pass through unchanged.
+func substituteTemplate(tmpl []string, clonePath string) []string {
+	if len(tmpl) == 0 {
+		return nil
+	}
+	out := make([]string, len(tmpl))
+	for i, tok := range tmpl {
+		if tok == "{}" {
+			out[i] = clonePath
+		} else {
+			out[i] = tok
+		}
+	}
+	return out
 }

--- a/internal/uki/bootloader_test.go
+++ b/internal/uki/bootloader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -175,7 +176,7 @@ func TestApply_WritesBinaryAndRemovesOrphans(t *testing.T) {
 	out, err := gen.Generate(input)
 	require.NoError(t, err)
 
-	require.NoError(t, Apply(out, runner.New(false)))
+	require.NoError(t, Apply(out, runner.New(false), nil))
 
 	// the new clone exists and parses as a UKI
 	clones, err := filepath.Glob(filepath.Join(outDir, "uki-btrfs-snapshots-300-*.efi"))
@@ -209,7 +210,7 @@ func TestApply_DryRunTouchesNothing(t *testing.T) {
 	out, err := NewGenerator().Generate(input)
 	require.NoError(t, err)
 
-	require.NoError(t, Apply(out, runner.New(true)))
+	require.NoError(t, Apply(out, runner.New(true), nil))
 
 	// orphan stays on disk
 	_, err = os.Stat(orphanPath)
@@ -222,5 +223,108 @@ func TestApply_DryRunTouchesNothing(t *testing.T) {
 }
 
 func TestApply_NilOutput(t *testing.T) {
-	assert.NoError(t, Apply(nil, runner.New(false)))
+	assert.NoError(t, Apply(nil, runner.New(false), nil))
+}
+
+func TestSubstituteTemplate_ReplacesBraces(t *testing.T) {
+	tests := []struct {
+		tmpl []string
+		path string
+		want []string
+	}{
+		{[]string{"peseal", "sign", "{}"}, "/boot/x.efi", []string{"peseal", "sign", "/boot/x.efi"}},
+		{[]string{"sbsign", "--output", "{}", "{}"}, "/a.efi", []string{"sbsign", "--output", "/a.efi", "/a.efi"}},
+		{[]string{"echo", "no-placeholder"}, "/x", []string{"echo", "no-placeholder"}},
+		{nil, "/x", nil},
+	}
+	for _, tt := range tests {
+		got := substituteTemplate(tt.tmpl, tt.path)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func writeFakeSigner(t *testing.T, dir string) string {
+	t.Helper()
+	script := filepath.Join(dir, "fake-signer")
+	body := "#!/bin/sh\nprintf '%s\\n' \"$1\" >> " + filepath.Join(dir, "calls.log") + "\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	return script
+}
+
+func TestApply_RunsSignCommandAfterEachClone(t *testing.T) {
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "EFI", "Linux"), 0o755))
+
+	input := bootloader.Input{
+		Cfg:     cfgWith(true, "/EFI/Linux", "uki-btrfs-snapshots-"),
+		ESPPath: espDir,
+		ProcessedSnapshots: []*btrfs.Snapshot{
+			newSnap(256, "@/.snapshots/1/snapshot"),
+			newSnap(257, "@/.snapshots/2/snapshot"),
+		},
+		SourceUKIs: []*kernel.BootSet{srcUKI(t, "linux")},
+	}
+	out, err := NewGenerator().Generate(input)
+	require.NoError(t, err)
+
+	signer := writeFakeSigner(t, espDir)
+	signCmd := []string{signer, "{}"}
+
+	require.NoError(t, Apply(out, runner.New(false), signCmd))
+
+	log, err := os.ReadFile(filepath.Join(espDir, "calls.log"))
+	require.NoError(t, err)
+	calls := strings.Split(strings.TrimSpace(string(log)), "\n")
+	assert.Len(t, calls, 2, "sign command must run exactly once per clone")
+	for _, p := range calls {
+		assert.True(t, strings.HasSuffix(p, ".efi"), "called paths must be the clone paths")
+	}
+}
+
+func TestApply_NoSignCommandSkipsExec(t *testing.T) {
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "EFI", "Linux"), 0o755))
+	input := bootloader.Input{
+		Cfg:                cfgWith(true, "/EFI/Linux", "uki-btrfs-snapshots-"),
+		ESPPath:            espDir,
+		ProcessedSnapshots: []*btrfs.Snapshot{newSnap(256, "@/.snapshots/1/snapshot")},
+		SourceUKIs:         []*kernel.BootSet{srcUKI(t, "linux")},
+	}
+	out, _ := NewGenerator().Generate(input)
+	require.NoError(t, Apply(out, runner.New(false), nil), "nil sign command must be a no-op, not an error")
+}
+
+func TestApply_SignCommandFailureAggregatesIntoErrors(t *testing.T) {
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "EFI", "Linux"), 0o755))
+	input := bootloader.Input{
+		Cfg:                cfgWith(true, "/EFI/Linux", "uki-btrfs-snapshots-"),
+		ESPPath:            espDir,
+		ProcessedSnapshots: []*btrfs.Snapshot{newSnap(256, "@/.snapshots/1/snapshot")},
+		SourceUKIs:         []*kernel.BootSet{srcUKI(t, "linux")},
+	}
+	out, _ := NewGenerator().Generate(input)
+
+	// /bin/false exits 1 unconditionally — every clone's sign step fails.
+	err := Apply(out, runner.New(false), []string{"/bin/false", "{}"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sign", "sign failures must be visible in the aggregated error")
+}
+
+func TestApply_SignSkippedInDryRun(t *testing.T) {
+	espDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(espDir, "EFI", "Linux"), 0o755))
+	input := bootloader.Input{
+		Cfg:                cfgWith(true, "/EFI/Linux", "uki-btrfs-snapshots-"),
+		ESPPath:            espDir,
+		ProcessedSnapshots: []*btrfs.Snapshot{newSnap(256, "@/.snapshots/1/snapshot")},
+		SourceUKIs:         []*kernel.BootSet{srcUKI(t, "linux")},
+	}
+	out, _ := NewGenerator().Generate(input)
+
+	signer := writeFakeSigner(t, espDir)
+	require.NoError(t, Apply(out, runner.New(true), []string{signer, "{}"}))
+
+	_, err := os.Stat(filepath.Join(espDir, "calls.log"))
+	assert.True(t, os.IsNotExist(err), "dry-run must not actually exec the sign command")
 }


### PR DESCRIPTION
## Summary

Wires Secure Boot signing into the `uki-btrfs-snapshots` snapshot-cloning pipeline via a single configurable knob — `uki.sign_command` — plus the docs to make it usable across distros. Depends on #20 (peseal) being merged; that's the recommended default value of `sign_command` but not a hard dependency — users can point it at sbctl, sbsign, pesign, or any custom script.

This is the "inline mode" complement to the peseal `.path`-driven "decoupled mode" already shipped in #20. Users pick whichever fits their operational preference.

## What's in the PR

### Slice 6 — implementation (`122ee64`)

- New `internal/config.ShellArgv` type accepts both YAML shapes:
  - List form: `sign_command: ["peseal", "sign", "{}"]`
  - String form: `sign_command: "peseal sign {}"` (shellwords-split via a mapstructure decode hook)
- New `--sign-command` CLI flag mirroring the string form; overrides config.
- `internal/uki.Apply` gains a third parameter — the resolved argv. After each clone is written, `{}` tokens are substituted with the clone's absolute path and the command is exec'd via the existing `runner.Runner`. Per-clone failures aggregate into the existing error-join; dry-run goes through `runner.Command` which logs without executing.
- Adds `github.com/mattn/go-shellwords` for the shellwords parser.

### Slice 7 — docs (`544d097`)

- `configs/uki-btrfs-snapshots.yaml`: shipped sample gains commented `sign_command` alternatives covering all five common signers (peseal, sbctl, sbsign, pesign-via-wrapper, systemd-sbsign), each annotated with which distro typically packages it.
- **New `cmd/uki-btrfs-snapshots/README.md`**: per-distro template table, the Fedora pesign wrapper recipe, `{}` substitution semantics, operational notes on dry-run / per-clone error aggregation / idempotency by signer / sdbootutil ordering.
- `docs/USAGE.md`: UKI Layout section reframed from "not snapshot-bootable" to "snapshot-bootable via the sibling binary; signing configurable". Bootloader Coverage table replaces the `(planned)` UKI row with the shipped binary; adds a peseal row.
- Main `README.md`: FAQ rewrites the UKI question. Binaries table bumps from 3 → 5 rows (adds `uki-btrfs-snapshots` and `peseal`).
- `docs/WISHLIST.md`: 115 → 44 lines. Drops the (shipped) `uki-btrfs-snapshots binary` and `Secure Boot signing` sections. What remains: hardware-backed signing keys (pointing at [`cmd/peseal/TODO.md`](cmd/peseal/TODO.md) for the detailed roadmap), PCR signing for TPM-sealed disks, and four smaller open questions.

## Behaviour

- `sign_command` absent / empty → clones written unsigned (unchanged behaviour for existing users).
- `sign_command` set → command exec'd once per clone with `{}` replaced by the clone path. Exact-token substitution (`{}.sig` and `out={}` pass through unchanged).
- Dry-run: `runner.Command` honours the runner's dry-run flag and just logs what would be exec'd.
- Per-clone exec failures don't stop the rest of the batch; non-zero exit aggregates all failures.

## Test plan

- [x] `go test -race ./...` all 21 packages green
- [x] `go vet ./...` clean
- [x] New tests cover: ShellArgv list-form + string-form YAML parsing, `substituteTemplate` argv replacement, `Apply` with sign command (exec-per-clone), `Apply` without sign command (no-op), sign command failure aggregation, sign command skipped in dry-run
- [x] End-to-end smoke: `uki-btrfs-snapshots generate` with `sign_command="peseal sign {}"` against a fake-ESP fixture produces 2 clones; `peseal inspect` confirms each clone carries `Signer CN: smoke` (the test self-signed cert)
- [x] No regressions on the other binaries: refind/bls dry-runs identical to pre-PR output

## Out of scope

- Hardware-backed signing keys (separate work; tracked in [`cmd/peseal/TODO.md`](cmd/peseal/TODO.md))
- PCR signing for TPM-sealed disks (separate work; tracked in `docs/WISHLIST.md`)